### PR TITLE
Add database services and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,30 @@
 
 This project contains a minimal FastAPI backend. The service exposes a single health check endpoint and can be run in Docker.
 
-## Running with Docker
+## Running with Docker Compose
+
+The project includes a `docker-compose.yml` that starts the API together with
+Redis, MinIO, Qdrant and Postgres. Build and start the stack with:
 
 ```bash
-docker build -t flynkle-api .
-docker run -p 8000:8000 flynkle-api
+docker compose up --build
 ```
 
 The API will be available at `http://localhost:8000`.
+
+### Database migrations
+
+Alembic is configured for database migrations. Create a revision with:
+
+```bash
+alembic revision --autogenerate -m "message"
+```
+
+Apply migrations with:
+
+```bash
+alembic upgrade head
+```
 
 ## Endpoints
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+This directory stores Alembic migration scripts.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,46 @@
+from logging.config import fileConfig
+import os
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from app.db.database import Base, DATABASE_URL
+
+config = context.config
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,0 +1,14 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@postgres:5432/postgres",
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,17 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1.api import api_router
 
 app = FastAPI(title="Flynkle API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(api_router, prefix="/api/v1")
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"
+services:
+  api:
+    build: .
+    container_name: flynkle-api
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - redis
+      - minio
+      - qdrant
+  postgres:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - "6379:6379"
+  minio:
+    image: minio/minio:latest
+    restart: always
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+  qdrant:
+    image: qdrant/qdrant:latest
+    restart: always
+    ports:
+      - "6333:6333"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 fastapi
 uvicorn
+redis
+minio
+qdrant-client
+SQLAlchemy
+psycopg2-binary
+alembic


### PR DESCRIPTION
## Summary
- add Docker Compose stack with Redis, MinIO, Qdrant and Postgres
- configure CORS middleware
- add SQLAlchemy DB session and Alembic config
- update dependencies for new features
- document running the stack and migrations

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6884e89dd8d883278e408f788212b9b7