### PR TITLE
Add chat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ docker compose up --build
 
 The API will be available at `http://localhost:8000`.
 
+### Environment variables
+
+Copy `.env.example` to `.env` and fill in the values. To enable the chat
+endpoint you must provide a valid `OPENAI_API_KEY`.
+
 ### Database migrations
 
 Alembic is configured for database migrations. Create a revision with:
@@ -32,5 +37,6 @@ alembic upgrade head
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | GET | `/api/v1/health` | Returns `{"status": "ok"}` |
+| POST | `/api/v1/chat` | Chat with OpenAI GPT-4 |
 
 A root endpoint (`/`) is also available which returns a welcome message but is not included in the OpenAPI schema.

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import health
+from app.api.v1.endpoints import health, chat
 
 api_router = APIRouter()
 api_router.include_router(health.router)
+api_router.include_router(chat.router)

--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -1,0 +1,17 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.concurrency import run_in_threadpool
+
+from app.schemas.chat import ChatRequest, ChatResponse
+from app.services.llm import chat_with_openai
+
+router = APIRouter()
+
+
+@router.post('/chat', response_model=ChatResponse, summary='Chat with OpenAI GPT-4')
+async def chat(request: ChatRequest) -> ChatResponse:
+    try:
+        response = await run_in_threadpool(chat_with_openai, request.message)
+        return ChatResponse(response=response)
+    except Exception as exc:  # pragma: no cover - simple catch
+        raise HTTPException(status_code=500, detail='LLM request failed') from exc
+

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+class ChatRequest(BaseModel):
+    message: str
+
+class ChatResponse(BaseModel):
+    response: str
+

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,0 +1,15 @@
+import os
+from typing import Any
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+def chat_with_openai(message: str) -> str:
+    """Send a prompt to OpenAI GPT-4 and return the response."""
+    response: Any = openai.ChatCompletion.create(
+        model="gpt-4",
+        messages=[{"role": "user", "content": message}],
+    )
+    return response["choices"][0]["message"]["content"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ qdrant-client
 SQLAlchemy
 psycopg2-binary
 alembic
+openai


### PR DESCRIPTION
## Summary
- add basic OpenAI GPT-4 chat endpoint
- include new chat models and service
- document required `OPENAI_API_KEY` and new endpoint
- install `openai` dependency

## Testing
- `pip install -q -r requirements.txt`
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_688505b1be308327b729a8cd532a4b9c