### PR TITLE
Enable hot reload and document API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@ This project contains a minimal FastAPI backend. The service exposes a single he
 ## Running with Docker Compose
 
 The project includes a `docker-compose.yml` that starts the API together with
-Redis, MinIO, Qdrant and Postgres. Build and start the stack with:
+Redis, MinIO, Qdrant and Postgres. Build the stack once and start it with:
 
 ```bash
 docker compose up --build
 ```
 
 The API will be available at `http://localhost:8000`.
+
+With the default setup the source code is mounted into the container and
+Uvicorn runs in reload mode. This means you do **not** need to rebuild the
+Docker image when making code changes. Rebuild only when you add new Python
+dependencies.
 
 ### Environment variables
 
@@ -37,6 +42,6 @@ alembic upgrade head
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | GET | `/api/v1/health` | Returns `{"status": "ok"}` |
-| POST | `/api/v1/chat` | Chat with OpenAI GPT-4 |
+| POST | `/api/v1/chat` | Chat with OpenAI GPT-4. Body: `{"message": "<text>"}`. Returns `{"response": "<reply>"}` |
+| GET | `/` | Returns a welcome message (not in the OpenAPI schema) |
 
-A root endpoint (`/`) is also available which returns a welcome message but is not included in the OpenAPI schema.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/postgres
     ports:
       - "8000:8000"
+    volumes:
+      - .:/app
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
## Summary
- mount source into container for development
- run uvicorn with `--reload`
- document new development workflow and API request details

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68850d0d5f10832780e467502cf2b14d