### PR TITLE
Add user management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Project Guide
+
+This repository contains a lightweight FastAPI service for Flynkle.
+
+## About the app
+- Demonstrates health and chat endpoints.
+- Provides basic user management with CRUD operations.
+- Shows a minimal architecture for experimentation.
+
+### Aims
+- Keep the code small and easy to understand.
+- Update the route table in the README whenever endpoints change.
+- Avoid unnecessary complexity so future updates remain simple.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Flynkle API Backend
 
-This project contains a minimal FastAPI backend. The service exposes a single health check endpoint and can be run in Docker.
+This project contains a minimal FastAPI backend that demonstrates a few basic features.
+
+## About
+
+- Health check endpoint
+- Chat endpoint backed by OpenAI
+- Basic user management
+
+The aim of the project is to stay lightweight and easy to extend.
 
 ## Running with Docker Compose
 
@@ -43,5 +51,10 @@ alembic upgrade head
 | ------ | ---- | ----------- |
 | GET | `/api/v1/health` | Returns `{"status": "ok"}` |
 | POST | `/api/v1/chat` | Chat with OpenAI GPT-4. Body: `{"message": "<text>"}`. Returns `{"response": "<reply>"}` |
+| GET | `/api/v1/users` | List users with pagination and search |
+| POST | `/api/v1/users` | Create a new user |
+| GET | `/api/v1/users/{user_id}` | Retrieve a user by ID |
+| PUT | `/api/v1/users/{user_id}` | Update a user |
+| DELETE | `/api/v1/users/{user_id}` | Soft delete a user |
 | GET | `/` | Returns a welcome message (not in the OpenAPI schema) |
 

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import health, chat
+from app.api.v1.endpoints import health, chat, users
 
 api_router = APIRouter()
 api_router.include_router(health.router)
 api_router.include_router(chat.router)
+api_router.include_router(users.router)

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -1,0 +1,54 @@
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.db.database import get_db
+from app.repositories import user as user_repo
+from app.schemas import UserCreate, UserRead, UserUpdate
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+@router.post("", response_model=UserRead, summary="Create user")
+def create_user(user_in: UserCreate, db: Session = Depends(get_db)) -> UserRead:
+    return user_repo.create_user(db, user_in)
+
+
+@router.get("/{user_id}", response_model=UserRead, summary="Get user")
+def get_user(user_id: UUID, db: Session = Depends(get_db)) -> UserRead:
+    user = user_repo.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.get("", response_model=List[UserRead], summary="List users")
+def list_users(
+    skip: int = 0,
+    limit: int = 100,
+    search: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+) -> List[UserRead]:
+    return user_repo.list_users(db, skip=skip, limit=limit, search=search)
+
+
+@router.put("/{user_id}", response_model=UserRead, summary="Update user")
+def update_user(
+    user_id: UUID,
+    user_in: UserUpdate,
+    db: Session = Depends(get_db),
+) -> UserRead:
+    user = user_repo.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user_repo.update_user(db, user, user_in)
+
+
+@router.delete("/{user_id}", response_model=UserRead, summary="Delete user")
+def delete_user(user_id: UUID, db: Session = Depends(get_db)) -> UserRead:
+    user = user_repo.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user_repo.delete_user(db, user)

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -2,6 +2,7 @@ import os
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+from typing import Generator
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
@@ -12,3 +13,11 @@ engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
+
+
+def get_db() -> Generator:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,3 @@
+from .user import User
+
+__all__ = ["User"]

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,31 @@
+import uuid
+from sqlalchemy import Column, String, Boolean, DateTime, JSON, func
+from sqlalchemy.dialects.postgresql import UUID
+
+from app.db.database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    user_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    email = Column(String, unique=True, index=True, nullable=True)
+    phone_number = Column(String, unique=True, index=True, nullable=True)
+    provider = Column(String, nullable=False)
+    provider_id = Column(String, index=True, nullable=True)
+
+    is_verified = Column(Boolean, default=False)
+    verified_at = Column(DateTime, nullable=True)
+
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    last_login_at = Column(DateTime, nullable=True)
+    last_login_ip = Column(String, nullable=True)
+
+    profile = Column(JSON, server_default='{}')
+
+    is_active = Column(Boolean, default=True)
+    is_admin = Column(Boolean, default=False)
+
+    is_deleted = Column(Boolean, default=False)

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,0 +1,3 @@
+from . import user
+
+__all__ = ["user"]

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,10 @@
+from .chat import ChatRequest, ChatResponse
+from .user import UserCreate, UserRead, UserUpdate
+
+__all__ = [
+    "ChatRequest",
+    "ChatResponse",
+    "UserCreate",
+    "UserRead",
+    "UserUpdate",
+]

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,30 @@
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, EmailStr
+
+
+class UserBase(BaseModel):
+    email: Optional[EmailStr] = None
+    phone_number: Optional[str] = None
+    provider: Optional[str] = None
+    provider_id: Optional[str] = None
+    is_verified: Optional[bool] = False
+    profile: Optional[dict] = None
+    is_active: Optional[bool] = True
+    is_admin: Optional[bool] = False
+
+
+class UserCreate(UserBase):
+    provider: str
+
+
+class UserUpdate(UserBase):
+    pass
+
+
+class UserRead(UserBase):
+    user_id: UUID
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- add project guide with features
- support CRUD user management with search and pagination
- expose user routes via API router
- document new endpoints in README

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885aed9185c8327a60d545f2c5dea3b