### PR TITLE
Run migrations automatically in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Apply migrations with:
 alembic upgrade head
 ```
 
+When you start the stack with Docker Compose the API container will
+automatically apply migrations before launching Uvicorn.
+
 ## Endpoints
 
 | Method | Path | Description |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+# Run database migrations
+alembic upgrade head
+
+exec "$@"


### PR DESCRIPTION
## Summary
- ensure Alembic migrations run whenever the container starts
- document automatic migrations in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885b30dbef88327bfc5467f3d632db9