### PR TITLE
Fix build error from alembic import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
+# Ensure our modules can be imported when running CLI tools like Alembic
+ENV PYTHONPATH=/app
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- set `PYTHONPATH` in Dockerfile so alembic can import the `app` package

## Testing
- `pip check`
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6885b579f87083279c7437fcf1f0ad66