### PR TITLE
Undo auto migration on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,12 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
+# Ensure our modules can be imported when running CLI tools like Alembic
+ENV PYTHONPATH=/app
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
-
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
-ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Apply migrations with:
 alembic upgrade head
 ```
 
-When you start the stack with Docker Compose the API container will
-automatically apply migrations before launching Uvicorn.
 
 ## Endpoints
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -e
-
-# Run database migrations
-alembic upgrade head
-
-exec "$@"


### PR DESCRIPTION
## Summary
- drop entrypoint script that ran migrations automatically
- keep PYTHONPATH but simplify Dockerfile
- remove mention of automatic migrations from docs

## Testing
- `pip check`
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6885b579f87083279c7437fcf1f0ad66