### PR TITLE
Add global SQLAlchemy error handler

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,10 +1,12 @@
 import logging
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from dotenv import load_dotenv
 
 from app.api.v1.api import api_router
+from sqlalchemy.exc import SQLAlchemyError
 
 load_dotenv()
 
@@ -12,6 +14,13 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Flynkle API", version="0.1.0")
+
+
+@app.exception_handler(SQLAlchemyError)
+async def handle_db_exceptions(request: Request, exc: SQLAlchemyError):
+    """Return a JSON response for database errors instead of crashing."""
+    logger.exception("Database error")
+    return JSONResponse(status_code=500, content={"detail": "Database error"})
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- handle SQLAlchemy errors globally so missing tables don't crash the server

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885befde7448327b686dd69a3bdbfae