### PR TITLE
Implement secure password flow

### DIFF
--- a/alembic/versions/ae102fee8486_add_password_hash.py
+++ b/alembic/versions/ae102fee8486_add_password_hash.py
@@ -1,0 +1,20 @@
+"""add password_hash column"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'ae102fee8486'
+down_revision: Union[str, Sequence[str], None] = '589f176ec05a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('password_hash', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'password_hash')

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,12 @@
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+def hash_password(password: str) -> str:
+    """Hash a plain text password."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, password_hash: str) -> bool:
+    """Verify a plain password against the hash."""
+    return pwd_context.verify(plain_password, password_hash)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -13,7 +13,6 @@ class UserBase(BaseModel):
     profile: Optional[dict] = None
     is_active: Optional[bool] = True
     is_admin: Optional[bool] = False
-    password: Optional[str] = None
 
 
 class UserCreate(UserBase):
@@ -22,7 +21,7 @@ class UserCreate(UserBase):
 
 
 class UserUpdate(UserBase):
-    pass
+    password: Optional[str] = None
 
 
 class UserRead(UserBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ openai
 python-dotenv
 email-validator
 dotenv
+passlib[bcrypt]

--- a/tests/test_password_flow.py
+++ b/tests/test_password_flow.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.db.database import Base
+from app.repositories import user as user_repo
+from app.schemas.user import UserCreate, UserUpdate
+from app.core.security import verify_password
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+def test_create_user_hashes_password(db):
+    user_in = UserCreate(provider="email", email="test@example.com", password="secret")
+    user = user_repo.create_user(db, user_in)
+    assert user.password_hash != "secret"
+    assert verify_password("secret", user.password_hash)
+
+def test_update_user_password(db):
+    user_in = UserCreate(provider="email", email="update@example.com", password="old")
+    user = user_repo.create_user(db, user_in)
+    user_repo.update_user(db, user, UserUpdate(password="new"))
+    assert verify_password("new", user.password_hash)
+    assert not verify_password("old", user.password_hash)


### PR DESCRIPTION
## Summary
- hash user passwords using passlib
- store hashed password on user create/update
- hide password from UserRead schema
- add alembic migration for password_hash column
- add tests validating password hashing
- include passlib in requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885c8e074948327a21c365fcf77c4da