### PR TITLE
Handle duplicate user creation errors

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,6 @@
 import logging
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from dotenv import load_dotenv
@@ -21,6 +21,13 @@ async def handle_db_exceptions(request: Request, exc: SQLAlchemyError):
     """Return a JSON response for database errors instead of crashing."""
     logger.exception("Database error")
     return JSONResponse(status_code=500, content={"detail": "Database error"})
+
+
+@app.exception_handler(HTTPException)
+async def handle_http_exceptions(request: Request, exc: HTTPException):
+    """Return a consistent JSON structure for HTTP errors."""
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+
 
 app.add_middleware(
     CORSMiddleware,

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -1,0 +1,40 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.database import Base, get_db
+
+
+@pytest.fixture
+def client():
+    engine = create_engine("sqlite:///./test.db", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    os.remove("test.db")
+
+
+def test_create_duplicate_user(client):
+    data = {"provider": "email", "email": "dup@example.com", "password": "pwd"}
+    resp1 = client.post("/api/v1/users", json=data)
+    assert resp1.status_code == 200
+    resp2 = client.post("/api/v1/users", json=data)
+    assert resp2.status_code == 400
+    assert resp2.json() == {"detail": "User already exists"}


### PR DESCRIPTION
## Summary
- handle duplicate user creation with a proper error message
- add global HTTPException handler
- add regression test for duplicate user creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d29c37d883278f4e2fdd312ef421