### PR TITLE
Add user plan field and developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project contains a minimal FastAPI backend that demonstrates a few basic fe
 - Health check endpoint
 - Chat endpoint backed by OpenAI
 - Basic user management
+- Users have a `plan` field with `free` as the default
 
 The aim of the project is to stay lightweight and easy to extend.
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -29,6 +29,8 @@ class User(Base):
     is_admin = Column(Boolean, default=False)
 
     is_deleted = Column(Boolean, default=False)
-    
+
+    plan = Column(String, default="free")
+
     password_hash = Column(String, nullable=True)
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -13,6 +13,7 @@ class UserBase(BaseModel):
     profile: Optional[dict] = None
     is_active: Optional[bool] = True
     is_admin: Optional[bool] = False
+    plan: Optional[str] = "free"
 
 
 class UserCreate(UserBase):

--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -1,0 +1,41 @@
+# Developer API & Schema Overview
+
+This document summarizes the planned API endpoints and database tables for the personal AI application. It is based on the high level design notes but simplified to fit the current lightweight service.
+
+## Database Tables
+
+### Users
+- `user_id` **UUID** primary key
+- `email` **TEXT** unique, nullable
+- `phone_number` **TEXT** unique, nullable
+- `provider` **TEXT** provider type
+- `provider_id` **TEXT** provider identifier
+- `is_verified` **BOOLEAN**
+- `verified_at` **TIMESTAMP**
+- `plan` **TEXT** user's subscription plan (default `"free"`)
+- `created_at` **TIMESTAMP**
+- `updated_at` **TIMESTAMP**
+- `last_login_at` **TIMESTAMP**
+- `profile` **JSONB** misc preferences
+- `is_active` **BOOLEAN**
+- `is_admin` **BOOLEAN**
+- `is_deleted` **BOOLEAN** soft delete flag
+- `password_hash` **TEXT**
+
+## API Endpoints
+
+The current service exposes a minimal set of endpoints:
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET    | `/api/v1/health` | Health check |
+| POST   | `/api/v1/chat`   | Chat with the AI model |
+| GET    | `/api/v1/users` | List users |
+| POST   | `/api/v1/users` | Create a new user |
+| GET    | `/api/v1/users/{user_id}` | Retrieve a user by ID |
+| PUT    | `/api/v1/users/{user_id}` | Update a user |
+| DELETE | `/api/v1/users/{user_id}` | Soft delete a user |
+
+This table matches the one in the main `README.md` and should be updated whenever routes change.
+
+Future revisions may introduce conversations, messages and usage tracking to enforce plan quotas as outlined in the design document.

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -38,3 +38,10 @@ def test_create_duplicate_user(client):
     resp2 = client.post("/api/v1/users", json=data)
     assert resp2.status_code == 400
     assert resp2.json() == {"detail": "User already exists"}
+
+
+def test_user_has_default_plan(client):
+    data = {"provider": "email", "email": "plan@example.com", "password": "pwd"}
+    resp = client.post("/api/v1/users", json=data)
+    assert resp.status_code == 200
+    assert resp.json()["plan"] == "free"


### PR DESCRIPTION
## Summary
- add a `plan` field to the `User` model and schema
- document available tables and endpoints in `docs/DEVELOPER_API.md`
- mention default plan in README
- test that new users have the default plan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885d794a91c832797428d15501d2126