### PR TITLE
Implement conversation and message tables

### DIFF
--- a/alembic/versions/8fc6b18b1fb2_add_conversation_tables.py
+++ b/alembic/versions/8fc6b18b1fb2_add_conversation_tables.py
@@ -1,0 +1,75 @@
+"""add conversation tables
+
+Revision ID: 8fc6b18b1fb2
+Revises: ae102fee8486
+Create Date: 2025-07-27 08:09:46.414296
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8fc6b18b1fb2'
+down_revision: Union[str, Sequence[str], None] = 'ae102fee8486'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "conversations",
+        sa.Column("conversation_id", sa.UUID(), primary_key=True),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.user_id"), nullable=False),
+        sa.Column("title", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+        sa.Column("status", sa.String(), nullable=True),
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("message_id", sa.UUID(), primary_key=True),
+        sa.Column(
+            "conversation_id",
+            sa.UUID(),
+            sa.ForeignKey("conversations.conversation_id"),
+            nullable=False,
+        ),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.user_id"), nullable=True),
+        sa.Column("content", sa.JSON(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("message_type", sa.String(), nullable=False),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+    )
+
+    op.create_table(
+        "usage",
+        sa.Column("usage_id", sa.UUID(), primary_key=True),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.user_id"), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("message_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("token_count", sa.Integer(), nullable=True),
+        sa.Column("file_uploads", sa.Integer(), nullable=True),
+        sa.Column(
+            "last_updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("usage")
+    op.drop_table("messages")
+    op.drop_table("conversations")

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,6 +1,6 @@
 # app/db/base.py
-from app.models.user import User  # include all future models here
+from app.models import User, Conversation, Message, Usage  # include all models here
 from app.db.database import Base
 
 # This file ensures all models are registered for Alembic
-__all__ = ["User"]
+__all__ = ["User", "Conversation", "Message", "Usage"]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,6 @@
 from .user import User
+from .conversation import Conversation
+from .message import Message
+from .usage import Usage
 
-__all__ = ["User"]
+__all__ = ["User", "Conversation", "Message", "Usage"]

--- a/app/models/conversation.py
+++ b/app/models/conversation.py
@@ -1,0 +1,17 @@
+import uuid
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from app.db.database import Base
+
+
+class Conversation(Base):
+    __tablename__ = "conversations"
+
+    conversation_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"), nullable=False)
+    title = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now())
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    status = Column(String, nullable=True)

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -1,0 +1,18 @@
+import uuid
+from sqlalchemy import Column, String, DateTime, ForeignKey, JSON
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from app.db.database import Base
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    message_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.conversation_id"), nullable=False)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"), nullable=True)
+    content = Column(JSON, nullable=False)
+    timestamp = Column(DateTime, server_default=func.now())
+    message_type = Column(String, nullable=False)
+    extra = Column("metadata", JSON, nullable=True)

--- a/app/models/usage.py
+++ b/app/models/usage.py
@@ -1,0 +1,18 @@
+import uuid
+from sqlalchemy import Column, Date, DateTime, Integer, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from app.db.database import Base
+
+
+class Usage(Base):
+    __tablename__ = "usage"
+
+    usage_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"), nullable=False)
+    date = Column(Date, nullable=False)
+    message_count = Column(Integer, nullable=False, default=0)
+    token_count = Column(Integer, nullable=True)
+    file_uploads = Column(Integer, nullable=True)
+    last_updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -21,6 +21,32 @@ This document summarizes the planned API endpoints and database tables for the p
 - `last_login` **TIMESTAMP**
 - `profile` **JSONB** misc preferences
 
+### Conversations
+- `conversation_id` **UUID** primary key
+- `user_id` **UUID** foreign key to `users`
+- `title` **TEXT** optional title
+- `created_at` **TIMESTAMP** when the conversation was created
+- `updated_at` **TIMESTAMP** updated on each message
+- `status` **TEXT** state such as `active` or `archived`
+
+### Messages
+- `message_id` **UUID** primary key
+- `conversation_id` **UUID** foreign key to `conversations`
+- `user_id` **UUID** foreign key to `users` (nullable for system/AI messages)
+- `content` **JSONB** message body or structured data
+- `timestamp` **TIMESTAMP** when the message was created
+- `message_type` **TEXT** e.g. `user`, `ai`, `system`
+- `metadata` **JSONB** optional extra info
+
+### Usage
+- `usage_id` **UUID** primary key
+- `user_id` **UUID** foreign key to `users`
+- `date` **DATE** day the usage entry applies to
+- `message_count` **INT** messages sent on that day
+- `token_count` **INT** optional token count
+- `file_uploads` **INT** optional upload count
+- `last_updated_at` **TIMESTAMP** updated when counts change
+
 ## API Endpoints
 
 The current service exposes a minimal set of endpoints:
@@ -37,4 +63,4 @@ The current service exposes a minimal set of endpoints:
 
 This table matches the one in the main `README.md` and should be updated whenever routes change.
 
-Future revisions may introduce conversations, messages and usage tracking to enforce plan quotas as outlined in the design document.
+These tables enable conversation history and quota tracking which can be used to enforce subscription plans.


### PR DESCRIPTION
## Summary
- add DB models for conversations, messages and usage
- register new models with SQLAlchemy base
- create Alembic migration to create the new tables
- document the new tables in Developer API docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885de1306c88327ac95d5ca3c16df62