### PR TITLE
Expand API routes with conversation and usage features

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,24 @@ alembic upgrade head
 | PUT | `/api/v1/users/{user_id}` | Update a user |
 | DELETE | `/api/v1/users/{user_id}` | Delete a user |
 | GET | `/` | Returns a welcome message (not in the OpenAPI schema) |
+| POST | `/api/v1/auth/login` | Login placeholder |
+| POST | `/api/v1/auth/logout` | Logout placeholder |
+| POST | `/api/v1/auth/verify` | Verification placeholder |
+| GET | `/api/v1/users/me` | Get current user |
+| PATCH | `/api/v1/users/me` | Update current user |
+| DELETE | `/api/v1/users/me` | Delete current user |
+| GET | `/api/v1/plans` | List available plans |
+| GET | `/api/v1/user/usage` | Get usage for current user |
+| POST | `/api/v1/user/upgrade` | Change user plan |
+| GET | `/api/v1/conversations` | List user conversations |
+| POST | `/api/v1/conversations` | Create conversation |
+| GET | `/api/v1/conversations/{conversation_id}` | Get conversation |
+| PATCH | `/api/v1/conversations/{conversation_id}` | Update conversation |
+| DELETE | `/api/v1/conversations/{conversation_id}` | Delete conversation |
+| GET | `/api/v1/conversations/{conversation_id}/messages` | List messages in conversation |
+| POST | `/api/v1/conversations/{conversation_id}/messages` | Create message in conversation |
+| GET | `/api/v1/messages/{message_id}` | Get message |
+| DELETE | `/api/v1/messages/{message_id}` | Delete message |
+| GET | `/api/v1/admin/users` | Admin list users |
+| PATCH | `/api/v1/admin/users/{user_id}` | Admin update user |
 

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,0 +1,21 @@
+from uuid import UUID
+from fastapi import Header, HTTPException, Depends
+from sqlalchemy.orm import Session
+
+from app.db.database import get_db
+from app.repositories import user as user_repo
+
+
+def get_current_user(
+    user_id: UUID = Header(..., alias="X-User-ID"),
+    db: Session = Depends(get_db),
+):
+    user = user_repo.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+def verify_admin(admin: str = Header(None, alias="X-Admin")):
+    if admin != "true":
+        raise HTTPException(status_code=403, detail="Admin privileges required")

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,8 +1,20 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import health, chat, users
+from app.api.v1.endpoints import (
+    health,
+    chat,
+    users,
+    auth,
+    plans,
+    conversations,
+    admin,
+)
 
 api_router = APIRouter()
 api_router.include_router(health.router)
 api_router.include_router(chat.router)
 api_router.include_router(users.router)
+api_router.include_router(auth.router)
+api_router.include_router(plans.router)
+api_router.include_router(conversations.router)
+api_router.include_router(admin.router)

--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -1,0 +1,17 @@
+from .auth import router as auth_router
+from .chat import router as chat_router
+from .health import router as health_router
+from .users import router as users_router
+from .plans import router as plans_router
+from .conversations import router as conversations_router
+from .admin import router as admin_router
+
+__all__ = [
+    "auth_router",
+    "chat_router",
+    "health_router",
+    "users_router",
+    "plans_router",
+    "conversations_router",
+    "admin_router",
+]

--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -1,0 +1,33 @@
+from uuid import UUID
+from typing import List, Optional
+from fastapi import APIRouter, Depends, Query, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.deps import verify_admin
+from app.db.database import get_db
+from app.repositories import user as user_repo
+from app.schemas import UserRead, UserUpdate
+
+router = APIRouter(prefix="/admin", tags=["admin"], dependencies=[Depends(verify_admin)])
+
+
+@router.get("/users", response_model=List[UserRead], summary="List users (admin)")
+def admin_list_users(
+    skip: int = 0,
+    limit: int = 100,
+    search: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+) -> List[UserRead]:
+    return user_repo.list_users(db, skip=skip, limit=limit, search=search)
+
+
+@router.patch("/users/{user_id}", response_model=UserRead, summary="Update user (admin)")
+def admin_update_user(
+    user_id: UUID,
+    user_in: UserUpdate,
+    db: Session = Depends(get_db),
+) -> UserRead:
+    user = user_repo.get_user(db, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user_repo.update_user(db, user, user_in)

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+@router.post("/login", summary="Login placeholder")
+def login() -> dict:
+    return {"detail": "login successful"}
+
+@router.post("/logout", summary="Logout placeholder")
+def logout() -> dict:
+    return {"detail": "logout successful"}
+
+@router.post("/verify", summary="Verification placeholder")
+def verify() -> dict:
+    return {"detail": "verification successful"}

--- a/app/api/v1/endpoints/conversations.py
+++ b/app/api/v1/endpoints/conversations.py
@@ -1,0 +1,145 @@
+from datetime import date
+from uuid import UUID
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.api.deps import get_current_user
+from app.db.database import get_db
+from app.repositories import conversation as convo_repo
+from app.repositories import message as message_repo
+from app.repositories import usage as usage_repo
+from app.repositories import user as user_repo
+from app.schemas import (
+    ConversationCreate,
+    ConversationRead,
+    ConversationUpdate,
+    MessageCreate,
+    MessageRead,
+)
+
+router = APIRouter(prefix="/conversations", tags=["conversations"])
+
+
+@router.get("", response_model=List[ConversationRead], summary="List conversations")
+def list_conversations(
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> List[ConversationRead]:
+    return convo_repo.list_conversations(db, current_user.user_id)
+
+
+@router.post("", response_model=ConversationRead, summary="Create conversation")
+def create_conversation(
+    convo_in: ConversationCreate,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ConversationRead:
+    return convo_repo.create_conversation(db, current_user.user_id, convo_in.title)
+
+
+@router.get("/{conversation_id}", response_model=ConversationRead, summary="Get conversation")
+def get_conversation(
+    conversation_id: UUID,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ConversationRead:
+    convo = convo_repo.get_conversation(db, conversation_id)
+    if not convo or convo.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return convo
+
+
+@router.patch("/{conversation_id}", response_model=ConversationRead, summary="Update conversation")
+def update_conversation(
+    conversation_id: UUID,
+    convo_in: ConversationUpdate,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ConversationRead:
+    convo = convo_repo.get_conversation(db, conversation_id)
+    if not convo or convo.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return convo_repo.update_conversation(db, convo, convo_in.title, convo_in.status)
+
+
+@router.delete("/{conversation_id}", response_model=ConversationRead, summary="Delete conversation")
+def delete_conversation(
+    conversation_id: UUID,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> ConversationRead:
+    convo = convo_repo.get_conversation(db, conversation_id)
+    if not convo or convo.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return convo_repo.delete_conversation(db, convo)
+
+
+@router.get("/{conversation_id}/messages", response_model=List[MessageRead], summary="List messages")
+def list_messages(
+    conversation_id: UUID,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    skip: int = 0,
+    limit: int = 100,
+) -> List[MessageRead]:
+    convo = convo_repo.get_conversation(db, conversation_id)
+    if not convo or convo.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    return message_repo.list_messages(db, conversation_id, skip=skip, limit=limit)
+
+
+@router.post("/{conversation_id}/messages", response_model=MessageRead, summary="Create message")
+def create_message(
+    conversation_id: UUID,
+    msg_in: MessageCreate,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> MessageRead:
+    convo = convo_repo.get_conversation(db, conversation_id)
+    if not convo or convo.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    # plan enforcement
+    if current_user.plan == "free":
+        daily = usage_repo.get_daily_usage(db, current_user.user_id, date.today())
+        if daily and daily.message_count >= 20:
+            raise HTTPException(status_code=403, detail="Upgrade required")
+    msg = message_repo.create_message(
+        db,
+        conversation_id,
+        current_user.user_id,
+        msg_in.content,
+        msg_in.message_type,
+    )
+    usage_repo.increment_message_count(db, current_user.user_id, date.today())
+    return msg
+
+
+@router.get("/messages/{message_id}", response_model=MessageRead, summary="Get message")
+def get_message(
+    message_id: UUID,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> MessageRead:
+    msg = message_repo.get_message(db, message_id)
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    convo = convo_repo.get_conversation(db, msg.conversation_id)
+    if not convo or convo.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return msg
+
+
+@router.delete("/messages/{message_id}", response_model=MessageRead, summary="Delete message")
+def delete_message(
+    message_id: UUID,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> MessageRead:
+    msg = message_repo.get_message(db, message_id)
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    convo = convo_repo.get_conversation(db, msg.conversation_id)
+    if not convo or convo.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return message_repo.delete_message(db, msg)

--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -1,0 +1,37 @@
+from datetime import date
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.api.deps import get_current_user
+from app.db.database import get_db
+from app.repositories import usage as usage_repo
+from app.schemas import UsageRead
+
+router = APIRouter(tags=["plans"])
+
+PLANS = {
+    "free": {"price": 0, "daily_messages": 20},
+    "pro": {"price": 10, "daily_messages": 1000},
+}
+
+@router.get("/plans", summary="Available plans")
+def list_plans() -> dict:
+    return PLANS
+
+@router.get("/user/usage", response_model=List[UsageRead], summary="User usage")
+def get_usage(
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return usage_repo.get_usage(db, current_user.user_id)
+
+@router.post("/user/upgrade", summary="Upgrade plan (stub)")
+def upgrade_plan(
+    plan: str,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> dict:
+    current_user.plan = plan
+    db.commit()
+    return {"detail": "plan updated"}

--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -57,3 +57,24 @@ def delete_user(user_id: UUID, db: Session = Depends(get_db)) -> UserRead:
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user_repo.delete_user(db, user)
+
+from app.api.deps import get_current_user
+
+@router.get("/me", response_model=UserRead, summary="Get current user")
+def read_me(current_user = Depends(get_current_user)) -> UserRead:
+    return current_user
+
+@router.patch("/me", response_model=UserRead, summary="Update current user")
+def update_me(
+    user_in: UserUpdate,
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserRead:
+    return user_repo.update_user(db, current_user, user_in)
+
+@router.delete("/me", response_model=UserRead, summary="Delete current user")
+def delete_me(
+    current_user = Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserRead:
+    return user_repo.delete_user(db, current_user)

--- a/app/repositories/conversation.py
+++ b/app/repositories/conversation.py
@@ -1,0 +1,36 @@
+from typing import List, Optional
+from uuid import UUID
+from sqlalchemy.orm import Session
+from app.models.conversation import Conversation
+
+
+def create_conversation(db: Session, user_id: UUID, title: Optional[str] = None) -> Conversation:
+    conv = Conversation(user_id=user_id, title=title)
+    db.add(conv)
+    db.commit()
+    db.refresh(conv)
+    return conv
+
+
+def get_conversation(db: Session, conversation_id: UUID) -> Optional[Conversation]:
+    return db.query(Conversation).filter(Conversation.conversation_id == conversation_id).first()
+
+
+def list_conversations(db: Session, user_id: UUID) -> List[Conversation]:
+    return db.query(Conversation).filter(Conversation.user_id == user_id).order_by(Conversation.created_at.desc()).all()
+
+
+def update_conversation(db: Session, conv: Conversation, title: Optional[str] = None, status: Optional[str] = None) -> Conversation:
+    if title is not None:
+        conv.title = title
+    if status is not None:
+        conv.status = status
+    db.commit()
+    db.refresh(conv)
+    return conv
+
+
+def delete_conversation(db: Session, conv: Conversation) -> Conversation:
+    db.delete(conv)
+    db.commit()
+    return conv

--- a/app/repositories/message.py
+++ b/app/repositories/message.py
@@ -1,0 +1,33 @@
+from typing import List, Optional
+from uuid import UUID
+from sqlalchemy.orm import Session
+from app.models.message import Message
+
+
+def create_message(db: Session, conversation_id: UUID, user_id: Optional[UUID], content: dict, message_type: str) -> Message:
+    msg = Message(conversation_id=conversation_id, user_id=user_id, content=content, message_type=message_type)
+    db.add(msg)
+    db.commit()
+    db.refresh(msg)
+    return msg
+
+
+def get_message(db: Session, message_id: UUID) -> Optional[Message]:
+    return db.query(Message).filter(Message.message_id == message_id).first()
+
+
+def list_messages(db: Session, conversation_id: UUID, skip: int = 0, limit: int = 100) -> List[Message]:
+    return (
+        db.query(Message)
+        .filter(Message.conversation_id == conversation_id)
+        .order_by(Message.timestamp)
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def delete_message(db: Session, msg: Message) -> Message:
+    db.delete(msg)
+    db.commit()
+    return msg

--- a/app/repositories/usage.py
+++ b/app/repositories/usage.py
@@ -1,0 +1,24 @@
+from datetime import date
+from typing import List, Optional
+from uuid import UUID
+from sqlalchemy.orm import Session
+from app.models.usage import Usage
+
+
+def get_usage(db: Session, user_id: UUID) -> List[Usage]:
+    return db.query(Usage).filter(Usage.user_id == user_id).order_by(Usage.date.desc()).all()
+
+
+def get_daily_usage(db: Session, user_id: UUID, day: date) -> Optional[Usage]:
+    return db.query(Usage).filter(Usage.user_id == user_id, Usage.date == day).first()
+
+
+def increment_message_count(db: Session, user_id: UUID, day: date) -> Usage:
+    usage = get_daily_usage(db, user_id, day)
+    if not usage:
+        usage = Usage(user_id=user_id, date=day, message_count=0)
+        db.add(usage)
+    usage.message_count += 1
+    db.commit()
+    db.refresh(usage)
+    return usage

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,5 +1,8 @@
 from .chat import ChatRequest, ChatResponse
 from .user import UserCreate, UserRead, UserUpdate
+from .conversation import ConversationCreate, ConversationRead, ConversationUpdate
+from .message import MessageCreate, MessageRead
+from .usage import UsageRead
 
 __all__ = [
     "ChatRequest",
@@ -7,4 +10,10 @@ __all__ = [
     "UserCreate",
     "UserRead",
     "UserUpdate",
+    "ConversationCreate",
+    "ConversationRead",
+    "ConversationUpdate",
+    "MessageCreate",
+    "MessageRead",
+    "UsageRead",
 ]

--- a/app/schemas/conversation.py
+++ b/app/schemas/conversation.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+from pydantic import BaseModel
+
+class ConversationBase(BaseModel):
+    title: Optional[str] = None
+    status: Optional[str] = None
+
+class ConversationCreate(ConversationBase):
+    pass
+
+class ConversationUpdate(ConversationBase):
+    pass
+
+class ConversationRead(ConversationBase):
+    conversation_id: UUID
+    user_id: UUID
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/message.py
+++ b/app/schemas/message.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+from pydantic import BaseModel
+
+class MessageBase(BaseModel):
+    content: dict
+    message_type: str
+
+class MessageCreate(MessageBase):
+    pass
+
+class MessageRead(MessageBase):
+    message_id: UUID
+    conversation_id: UUID
+    user_id: Optional[UUID] = None
+    timestamp: Optional[datetime] = None
+    extra: Optional[dict] = None
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/usage.py
+++ b/app/schemas/usage.py
@@ -1,0 +1,15 @@
+from datetime import date
+from uuid import UUID
+from typing import Optional
+from pydantic import BaseModel
+
+class UsageRead(BaseModel):
+    usage_id: UUID
+    user_id: UUID
+    date: date
+    message_count: int
+    token_count: Optional[int] = None
+    file_uploads: Optional[int] = None
+
+    class Config:
+        orm_mode = True

--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -60,6 +60,26 @@ The current service exposes a minimal set of endpoints:
 | GET    | `/api/v1/users/{user_id}` | Retrieve a user by ID |
 | PUT    | `/api/v1/users/{user_id}` | Update a user |
 | DELETE | `/api/v1/users/{user_id}` | Delete a user |
+| POST   | `/api/v1/auth/login` | Login placeholder |
+| POST   | `/api/v1/auth/logout` | Logout placeholder |
+| POST   | `/api/v1/auth/verify` | Verification placeholder |
+| GET    | `/api/v1/users/me` | Get current user |
+| PATCH  | `/api/v1/users/me` | Update current user |
+| DELETE | `/api/v1/users/me` | Delete current user |
+| GET    | `/api/v1/plans` | List available plans |
+| GET    | `/api/v1/user/usage` | Get usage for current user |
+| POST   | `/api/v1/user/upgrade` | Change user plan |
+| GET    | `/api/v1/conversations` | List user conversations |
+| POST   | `/api/v1/conversations` | Create conversation |
+| GET    | `/api/v1/conversations/{conversation_id}` | Get conversation |
+| PATCH  | `/api/v1/conversations/{conversation_id}` | Update conversation |
+| DELETE | `/api/v1/conversations/{conversation_id}` | Delete conversation |
+| GET    | `/api/v1/conversations/{conversation_id}/messages` | List messages in conversation |
+| POST   | `/api/v1/conversations/{conversation_id}/messages` | Create message in conversation |
+| GET    | `/api/v1/messages/{message_id}` | Get message |
+| DELETE | `/api/v1/messages/{message_id}` | Delete message |
+| GET    | `/api/v1/admin/users` | Admin list users |
+| PATCH  | `/api/v1/admin/users/{user_id}` | Admin update user |
 
 This table matches the one in the main `README.md` and should be updated whenever routes change.
 


### PR DESCRIPTION
## Summary
- add helper dependencies for obtaining current user and admin check
- implement new routers for auth, plans, conversations, and admin operations
- create repositories and schemas for conversations, messages, and usage
- wire new routers into API and extend existing user router
- document all new endpoints in README and developer docs
- enforce simple daily quota for free plan when sending messages

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885e029f95c8327a62b7d14b6e72102