### PR TITLE
Implement JWT login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Every endpoint wraps its payload in a simple envelope:
 
 Errors use the same structure with an appropriate status code and message.
 
+### Authentication
+
+Login returns a JWT access token. Pass it in the `Authorization` header as
+`Bearer <token>` when calling protected endpoints. Use `/auth/logout` and
+`/auth/verify` with the same header to logout or validate a token.
+
 
 ## Endpoints
 
@@ -73,9 +79,9 @@ Errors use the same structure with an appropriate status code and message.
 | PUT | `/api/v1/users/{user_id}` | Update a user |
 | DELETE | `/api/v1/users/{user_id}` | Delete a user |
 | GET | `/` | Returns a welcome message (not in the OpenAPI schema) |
-| POST | `/api/v1/auth/login` | Login placeholder |
-| POST | `/api/v1/auth/logout` | Logout placeholder |
-| POST | `/api/v1/auth/verify` | Verification placeholder |
+| POST | `/api/v1/auth/login` | Login and receive a token |
+| POST | `/api/v1/auth/logout` | Logout using token |
+| POST | `/api/v1/auth/verify` | Verify token validity |
 | GET | `/api/v1/users/me` | Get current user |
 | PATCH | `/api/v1/users/me` | Update current user |
 | DELETE | `/api/v1/users/me` | Delete current user |

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,15 +1,20 @@
-from uuid import UUID
 from fastapi import Header, HTTPException, Depends
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
 from app.repositories import user as user_repo
+from app.core import decode_access_token
 
 
 def get_current_user(
-    user_id: UUID = Header(..., alias="X-User-ID"),
+    authorization: str = Header(..., alias="Authorization"),
     db: Session = Depends(get_db),
 ):
+    token = authorization.replace("Bearer ", "")
+    try:
+        user_id = decode_access_token(token)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
     user = user_repo.get_user(db, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -1,19 +1,46 @@
-"""Authentication placeholder endpoints."""
+"""JWT-based authentication endpoints."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException, Header
+from sqlalchemy.orm import Session
 
-from app.core import success, StandardResponse
+from app.core import (
+    success,
+    StandardResponse,
+    verify_password,
+    create_access_token,
+    decode_access_token,
+)
+from app.db.database import get_db
+from app.repositories import user as user_repo
+from app.schemas import LoginRequest, TokenResponse
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-@router.post("/login", response_model=StandardResponse, summary="Login placeholder")
-def login() -> dict:
-    return success({"detail": "login successful"}).dict()
 
-@router.post("/logout", response_model=StandardResponse, summary="Logout placeholder")
-def logout() -> dict:
+@router.post("/login", response_model=StandardResponse, summary="Login")
+def login(credentials: LoginRequest, db: Session = Depends(get_db)) -> dict:
+    user = user_repo.get_user_by_email(db, credentials.email)
+    if not user or not verify_password(credentials.password, user.password):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = create_access_token(user.user_id)
+    return success(TokenResponse(access_token=token)).dict()
+
+
+@router.post("/logout", response_model=StandardResponse, summary="Logout")
+def logout(authorization: str = Header(..., alias="Authorization")) -> dict:
+    token = authorization.replace("Bearer ", "")
+    try:
+        decode_access_token(token)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
     return success({"detail": "logout successful"}).dict()
 
-@router.post("/verify", response_model=StandardResponse, summary="Verification placeholder")
-def verify() -> dict:
-    return success({"detail": "verification successful"}).dict()
+
+@router.post("/verify", response_model=StandardResponse, summary="Verify token")
+def verify(authorization: str = Header(..., alias="Authorization")) -> dict:
+    token = authorization.replace("Bearer ", "")
+    try:
+        user_id = decode_access_token(token)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return success({"user_id": str(user_id)}).dict()

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -2,7 +2,12 @@
 
 from .config import settings
 from .responses import StandardResponse, success
-from .security import hash_password, verify_password
+from .security import (
+    hash_password,
+    verify_password,
+    create_access_token,
+    decode_access_token,
+)
 
 __all__ = [
     "settings",
@@ -10,4 +15,6 @@ __all__ = [
     "success",
     "hash_password",
     "verify_password",
+    "create_access_token",
+    "decode_access_token",
 ]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,5 +5,8 @@ class Settings(BaseSettings):
 
     database_url: str = "postgresql://postgres:postgres@postgres:5432/postgres"
     openai_api_key: str = ""
+    secret_key: str = "secret"
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 60
 
 settings = Settings()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,4 +1,10 @@
+from datetime import datetime, timedelta
+from uuid import UUID
+
+import jwt
 from passlib.context import CryptContext
+
+from app.core.config import settings
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -10,3 +16,17 @@ def hash_password(password: str) -> str:
 def verify_password(plain_password: str, password_hash: str) -> bool:
     """Verify a plain password against the hash."""
     return pwd_context.verify(plain_password, password_hash)
+
+
+def create_access_token(user_id: UUID) -> str:
+    """Generate a JWT access token for the given user."""
+    expire = datetime.utcnow() + timedelta(minutes=settings.access_token_expire_minutes)
+    payload = {"sub": str(user_id), "exp": expire}
+    token = jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
+    return token
+
+
+def decode_access_token(token: str) -> UUID:
+    """Decode a JWT and return the user id."""
+    data = jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    return UUID(data["sub"])

--- a/app/repositories/user.py
+++ b/app/repositories/user.py
@@ -23,6 +23,11 @@ def get_user(db: Session, user_id: UUID) -> Optional[User]:
     return db.query(User).filter(User.user_id == user_id).first()
 
 
+def get_user_by_email(db: Session, email: str) -> Optional[User]:
+    """Retrieve a user by email."""
+    return db.query(User).filter(User.email == email).first()
+
+
 def update_user(db: Session, user: User, user_in: UserUpdate) -> User:
     update_data = user_in.dict(exclude_unset=True)
     password = update_data.pop("password", None)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -3,6 +3,16 @@ from .user import UserCreate, UserRead, UserUpdate
 from .conversation import ConversationCreate, ConversationRead, ConversationUpdate
 from .message import MessageCreate, MessageRead
 from .usage import UsageRead
+from pydantic import BaseModel
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
 
 __all__ = [
     "ChatRequest",
@@ -16,4 +26,6 @@ __all__ = [
     "MessageCreate",
     "MessageRead",
     "UsageRead",
+    "LoginRequest",
+    "TokenResponse",
 ]

--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -61,6 +61,12 @@ All endpoints return:
 
 Errors follow the same structure with an appropriate status code.
 
+### Authentication
+
+Login returns a JWT token. Include it in the `Authorization` header as
+`Bearer <token>` when accessing protected routes. Logout and verify use the
+same header.
+
 ## API Endpoints
 
 The current service exposes a minimal set of endpoints:
@@ -74,9 +80,9 @@ The current service exposes a minimal set of endpoints:
 | GET    | `/api/v1/users/{user_id}` | Retrieve a user by ID |
 | PUT    | `/api/v1/users/{user_id}` | Update a user |
 | DELETE | `/api/v1/users/{user_id}` | Delete a user |
-| POST   | `/api/v1/auth/login` | Login placeholder |
-| POST   | `/api/v1/auth/logout` | Logout placeholder |
-| POST   | `/api/v1/auth/verify` | Verification placeholder |
+| POST   | `/api/v1/auth/login` | Login and receive a token |
+| POST   | `/api/v1/auth/logout` | Logout using token |
+| POST   | `/api/v1/auth/verify` | Verify token validity |
 | GET    | `/api/v1/users/me` | Get current user |
 | PATCH  | `/api/v1/users/me` | Update current user |
 | DELETE | `/api/v1/users/me` | Delete current user |

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ email-validator
 dotenv
 passlib[bcrypt]
 pydantic-settings
+PyJWT

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -33,15 +33,19 @@ def client():
     os.remove("test_conv.db")
 
 
-def create_user(client):
+def create_token(client):
     data = {"provider": "email", "email": "conv@example.com", "password": "pwd"}
-    resp = client.post("/api/v1/users", json=data)
-    return resp.json()["data"]["user_id"]
+    client.post("/api/v1/users", json=data)
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"email": "conv@example.com", "password": "pwd"},
+    )
+    return resp.json()["data"]["access_token"]
 
 
 def test_plan_enforcement(client):
-    user_id = create_user(client)
-    headers = {"X-User-ID": user_id}
+    token = create_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
     conv = client.post("/api/v1/conversations", headers=headers, json={}).json()["data"]
     for i in range(20):
         resp = client.post(


### PR DESCRIPTION
## Summary
- add PyJWT dependency
- issue JWT tokens at `/auth/login`
- verify tokens via updated `get_current_user`
- implement `/auth/logout` and `/auth/verify`
- document authentication workflow and update route tables
- adjust conversation tests to use Authorization tokens

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885eb3f5fd883279b54793fab0893f5