### PR TITLE
Add admin role flag and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This project contains a minimal FastAPI backend that demonstrates a few basic fe
 - Chat endpoint backed by OpenAI
 - Basic user management
 - Users have a `plan` field with `free` as the default
+- Users have an `is_admin` flag for admin access
 
 The aim of the project is to stay lightweight and easy to extend.
 
@@ -93,4 +94,10 @@ Errors use the same structure with an appropriate status code and message.
 | DELETE | `/api/v1/messages/{message_id}` | Delete message |
 | GET | `/api/v1/admin/users` | Admin list users |
 | PATCH | `/api/v1/admin/users/{user_id}` | Admin update user |
+
+### Admin access
+
+Set `is_admin` to `true` on a user to grant admin rights. Admin endpoints
+require the `X-User-ID` header of an admin user. The old `X-Admin` header is no
+longer used.
 

--- a/alembic/versions/ba29ad6e9013_add_is_admin.py
+++ b/alembic/versions/ba29ad6e9013_add_is_admin.py
@@ -1,0 +1,18 @@
+"""add is_admin column"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'ba29ad6e9013'
+down_revision: Union[str, Sequence[str], None] = '8fc6b18b1fb2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('is_admin', sa.Boolean(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'is_admin')

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -7,15 +7,16 @@ from app.repositories import user as user_repo
 
 
 def get_current_user(
-    user_id: UUID = Header(..., alias="X-User-ID"),
+    current_user_id: UUID = Header(..., alias="X-User-ID"),
     db: Session = Depends(get_db),
 ):
-    user = user_repo.get_user(db, user_id)
+    user = user_repo.get_user(db, current_user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return user
 
 
-def verify_admin(admin: str = Header(None, alias="X-Admin")):
-    if admin != "true":
+def verify_admin(current_user = Depends(get_current_user)):
+    if not current_user.is_admin:
         raise HTTPException(status_code=403, detail="Admin privileges required")
+    return current_user

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -21,6 +21,7 @@ class User(Base):
     verified_at = Column(DateTime, nullable=True)
     is_active = Column(Boolean, default=True)
     is_suspended = Column(Boolean, default=False)
+    is_admin = Column(Boolean, default=False)
 
     plan = Column(String, default="free")
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -15,6 +15,7 @@ class UserBase(BaseModel):
     profile: Optional[dict] = None
     is_active: Optional[bool] = True
     is_suspended: Optional[bool] = False
+    is_admin: Optional[bool] = False
     plan: Optional[str] = "free"
 
 

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.database import Base, get_db
+
+
+@pytest.fixture
+def client():
+    engine = create_engine("sqlite:///./test_admin.db", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    os.remove("test_admin.db")
+
+
+def create_user(client, email, is_admin=False):
+    data = {"provider": "email", "email": email, "password": "pwd"}
+    if is_admin:
+        data["is_admin"] = True
+    resp = client.post("/api/v1/users", json=data)
+    return resp.json()["data"]["user_id"]
+
+
+def test_admin_required(client):
+    user_id = create_user(client, "user@example.com", is_admin=False)
+    headers = {"X-User-ID": user_id}
+    resp = client.get("/api/v1/admin/users", headers=headers)
+    assert resp.status_code == 403
+    assert resp.json()["message"] == "Admin privileges required"
+
+
+def test_admin_can_access(client):
+    admin_id = create_user(client, "admin@example.com", is_admin=True)
+    headers = {"X-User-ID": admin_id}
+    resp = client.get("/api/v1/admin/users", headers=headers)
+    assert resp.status_code == 200
+


### PR DESCRIPTION
## Summary
- add `is_admin` flag to `User`
- check flag in `verify_admin`
- document admin usage
- migrate schema for `is_admin`
- test admin-only routes

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885eb3ee57883278a1acaca7c202dec