### PR TITLE
Add login limit and user route protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ Errors use the same structure with an appropriate status code and message.
 ### Authentication
 
 Login returns a JWT access token. Pass it in the `Authorization` header as
-`Bearer <token>` when calling protected endpoints. Use `/auth/logout` and
-`/auth/verify` with the same header to logout or validate a token.
+`Bearer <token>` when calling protected endpoints. Accounts must be active and
+not suspended in order to authenticate. Excessive login attempts are rate
+limited. The `/auth/logout` endpoint now invalidates the provided token and
+`/auth/verify` checks that it is still valid.
 
 
 ## Endpoints
@@ -78,6 +80,7 @@ Login returns a JWT access token. Pass it in the `Authorization` header as
 | POST | `/api/v1/users` | Create a new user |
 | GET | `/api/v1/users/{user_id}` | Retrieve a user by ID |
 | PUT | `/api/v1/users/{user_id}` | Update a user |
+| PATCH | `/api/v1/users/{user_id}` | Partially update a user |
 | DELETE | `/api/v1/users/{user_id}` | Delete a user |
 | GET | `/` | Returns a welcome message (not in the OpenAPI schema) |
 | POST | `/api/v1/auth/login` | Login and receive a token |
@@ -101,6 +104,11 @@ Login returns a JWT access token. Pass it in the `Authorization` header as
 | DELETE | `/api/v1/messages/{message_id}` | Delete message |
 | GET | `/api/v1/admin/users` | Admin list users |
 | PATCH | `/api/v1/admin/users/{user_id}` | Admin update user |
+
+### User actions
+
+`PATCH` and `DELETE` on user resources require a valid token in the
+`Authorization` header (or `X-User-ID` for internal calls).
 
 ### Admin access
 

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,10 +1,14 @@
 from uuid import UUID
+import logging
 from fastapi import Header, HTTPException, Depends
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
 from app.repositories import user as user_repo
 from app.core import decode_access_token
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_current_user(
@@ -17,15 +21,21 @@ def get_current_user(
         try:
             user_id = decode_access_token(token)
         except Exception:
+            logger.warning("Invalid token used")
             raise HTTPException(status_code=401, detail="Invalid token")
     else:
         user_id = x_user_id
     if not user_id:
+        logger.warning("Missing credentials")
         raise HTTPException(status_code=401, detail="Missing credentials")
 
     user = user_repo.get_user(db, user_id)
     if not user:
+        logger.warning("User %s not found", user_id)
         raise HTTPException(status_code=404, detail="User not found")
+    if not user.is_active or user.is_suspended:
+        logger.warning("Inactive or suspended user %s", user.user_id)
+        raise HTTPException(status_code=403, detail="Account disabled")
     return user
 
 

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -7,6 +7,7 @@ from .security import (
     verify_password,
     create_access_token,
     decode_access_token,
+    revoke_token,
 )
 
 __all__ = [
@@ -17,4 +18,5 @@ __all__ = [
     "verify_password",
     "create_access_token",
     "decode_access_token",
+    "revoke_token",
 ]

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,6 +1,6 @@
 """Service utilities for the API."""
 
 from .llm import chat_with_openai
-from .rate_limiter import check_chat_rate_limit
+from .rate_limiter import check_chat_rate_limit, check_login_rate_limit
 
-__all__ = ["chat_with_openai", "check_chat_rate_limit"]
+__all__ = ["chat_with_openai", "check_chat_rate_limit", "check_login_rate_limit"]

--- a/app/services/rate_limiter.py
+++ b/app/services/rate_limiter.py
@@ -9,15 +9,29 @@ from fastapi import HTTPException
 RATE_LIMIT_WINDOW = 60  # seconds
 RATE_LIMIT_COUNT = 5
 
-_request_log: dict[UUID, deque[float]] = defaultdict(deque)
+_chat_log: dict[UUID, deque[float]] = defaultdict(deque)
+_login_log: dict[str, deque[float]] = defaultdict(deque)
+
+
+def _prune(q: deque[float]) -> None:
+    now = time.time()
+    while q and now - q[0] > RATE_LIMIT_WINDOW:
+        q.popleft()
 
 
 def check_chat_rate_limit(user_id: UUID) -> None:
     """Limit chat requests per user per time window."""
-    now = time.time()
-    q = _request_log[user_id]
-    while q and now - q[0] > RATE_LIMIT_WINDOW:
-        q.popleft()
+    q = _chat_log[user_id]
+    _prune(q)
     if len(q) >= RATE_LIMIT_COUNT:
         raise HTTPException(status_code=429, detail="Too many requests")
-    q.append(now)
+    q.append(time.time())
+
+
+def check_login_rate_limit(identifier: str) -> None:
+    """Limit login attempts per identifier (usually email)."""
+    q = _login_log[identifier]
+    _prune(q)
+    if len(q) >= RATE_LIMIT_COUNT:
+        raise HTTPException(status_code=429, detail="Too many login attempts")
+    q.append(time.time())

--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -64,8 +64,9 @@ Errors follow the same structure with an appropriate status code.
 ### Authentication
 
 Login returns a JWT token. Include it in the `Authorization` header as
-`Bearer <token>` when accessing protected routes. Logout and verify use the
-same header.
+`Bearer <token>` when accessing protected routes. Only active, non-suspended
+users can log in. Login is rate limited and `/auth/logout` invalidates the
+token while `/auth/verify` checks it.
 
 ## API Endpoints
 
@@ -79,6 +80,7 @@ The current service exposes a minimal set of endpoints:
 | POST   | `/api/v1/users` | Create a new user |
 | GET    | `/api/v1/users/{user_id}` | Retrieve a user by ID |
 | PUT    | `/api/v1/users/{user_id}` | Update a user |
+| PATCH  | `/api/v1/users/{user_id}` | Partially update a user |
 | DELETE | `/api/v1/users/{user_id}` | Delete a user |
 | POST   | `/api/v1/auth/login` | Login and receive a token |
 | POST   | `/api/v1/auth/logout` | Logout using token |
@@ -100,6 +102,11 @@ The current service exposes a minimal set of endpoints:
 | DELETE | `/api/v1/messages/{message_id}` | Delete message |
 | GET    | `/api/v1/admin/users` | Admin list users |
 | PATCH  | `/api/v1/admin/users/{user_id}` | Admin update user |
+
+### User actions
+
+`PATCH` and `DELETE` on user routes require authentication via the
+`Authorization` header or `X-User-ID`.
 
 This table matches the one in the main `README.md` and should be updated whenever routes change.
 


### PR DESCRIPTION
## Summary
- add login rate limiting and token revocation
- check `is_active` and `is_suspended` users
- secure user update and delete routes
- improve logging for auth and user endpoints
- update documentation about headers and new patch route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885fab92d308327b8ddc58716ff6932