### PR TITLE
Improve rate limiting and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This project contains a minimal FastAPI backend that demonstrates a few basic fe
 - Basic user management
 - Users have a `plan` field with `free` as the default
 - Users have an `is_admin` flag for admin access
+- Usage tracking captures daily message count, tokens and file uploads
+- Login updates the `last_login` timestamp
+- Chat, login and message creation endpoints are rate limited
 
 The aim of the project is to stay lightweight and easy to extend.
 
@@ -122,4 +125,11 @@ messages they can send per day. Exceeding these limits returns "Upgrade required
 Set `is_admin` to `true` on a user to grant admin rights. Admin endpoints
 require the `X-User-ID` header of an admin user. The old `X-Admin` header is no
 longer used.
+
+## Future Enhancements
+
+- Replace in-memory rate limiting with Redis for horizontal scaling
+- Add background job queue for long running tasks
+- Implement OAuth providers for enterprise authentication
+- Provide OpenAPI schemas for client code generation
 

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -32,6 +32,7 @@ def login(credentials: LoginRequest, db: Session = Depends(get_db)) -> dict:
         logger.warning("Inactive/suspended login attempt for %s", credentials.email)
         raise HTTPException(status_code=403, detail="Account disabled")
     token = create_access_token(user.user_id)
+    user_repo.update_last_login(db, user)
     logger.info("User %s logged in", user.user_id)
     return success(TokenResponse(access_token=token)).dict()
 

--- a/app/api/v1/endpoints/conversations.py
+++ b/app/api/v1/endpoints/conversations.py
@@ -13,7 +13,7 @@ from app.repositories import message as message_repo
 from app.repositories import usage as usage_repo
 from app.api.v1.endpoints.plans import PLANS
 from app.services.llm import chat_with_openai
-from app.services import check_chat_rate_limit
+from app.services import check_chat_rate_limit, check_message_rate_limit
 from app.schemas import (
     ConversationCreate,
     ConversationRead,
@@ -140,6 +140,7 @@ def create_message(
     convo = convo_repo.get_conversation(db, conversation_id)
     if not convo or convo.user_id != current_user.user_id:
         raise HTTPException(status_code=404, detail="Conversation not found")
+    check_message_rate_limit(current_user.user_id)
     # plan enforcement using configured plans
     plan = PLANS.get(current_user.plan, PLANS["free"])
     daily = usage_repo.get_daily_usage(db, current_user.user_id, date.today())

--- a/app/repositories/user.py
+++ b/app/repositories/user.py
@@ -7,6 +7,7 @@ from sqlalchemy import or_
 from app.models.user import User
 from app.schemas.user import UserCreate, UserUpdate
 from app.core.security import hash_password
+from datetime import datetime
 
 
 def create_user(db: Session, user_in: UserCreate) -> User:
@@ -38,6 +39,13 @@ def update_user(db: Session, user: User, user_in: UserUpdate) -> User:
     db.commit()
     db.refresh(user)
     return user
+
+
+def update_last_login(db: Session, user: User) -> None:
+    """Record the user's last login timestamp."""
+    user.last_login = datetime.utcnow()
+    db.commit()
+    db.refresh(user)
 
 
 def delete_user(db: Session, user: User) -> User:

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,6 +1,15 @@
 """Service utilities for the API."""
 
 from .llm import chat_with_openai
-from .rate_limiter import check_chat_rate_limit, check_login_rate_limit
+from .rate_limiter import (
+    check_chat_rate_limit,
+    check_login_rate_limit,
+    check_message_rate_limit,
+)
 
-__all__ = ["chat_with_openai", "check_chat_rate_limit", "check_login_rate_limit"]
+__all__ = [
+    "chat_with_openai",
+    "check_chat_rate_limit",
+    "check_login_rate_limit",
+    "check_message_rate_limit",
+]

--- a/app/services/rate_limiter.py
+++ b/app/services/rate_limiter.py
@@ -11,6 +11,7 @@ RATE_LIMIT_COUNT = 5
 
 _chat_log: dict[UUID, deque[float]] = defaultdict(deque)
 _login_log: dict[str, deque[float]] = defaultdict(deque)
+_message_log: dict[UUID, deque[float]] = defaultdict(deque)
 
 
 def _prune(q: deque[float]) -> None:
@@ -34,4 +35,13 @@ def check_login_rate_limit(identifier: str) -> None:
     _prune(q)
     if len(q) >= RATE_LIMIT_COUNT:
         raise HTTPException(status_code=429, detail="Too many login attempts")
+    q.append(time.time())
+
+
+def check_message_rate_limit(user_id: UUID) -> None:
+    """Limit how many messages a user can create per time window."""
+    q = _message_log[user_id]
+    _prune(q)
+    if len(q) >= RATE_LIMIT_COUNT:
+        raise HTTPException(status_code=429, detail="Too many messages")
     q.append(time.time())

--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -67,6 +67,8 @@ Login returns a JWT token. Include it in the `Authorization` header as
 `Bearer <token>` when accessing protected routes. Only active, non-suspended
 users can log in. Login is rate limited and `/auth/logout` invalidates the
 token while `/auth/verify` checks it.
+Message creation and `/chat` requests are also rate limited to prevent abuse.
+Successful login updates the `last_login` timestamp for the user.
 
 ## API Endpoints
 

--- a/tests/test_misc_api.py
+++ b/tests/test_misc_api.py
@@ -1,0 +1,68 @@
+import os
+import sys
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.database import Base, get_db
+from app.core import decode_access_token
+
+
+@pytest.fixture
+def client():
+    engine = create_engine("sqlite:///./test_misc.db", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    os.remove("test_misc.db")
+
+
+def create_user_and_login(client, email="user@example.com"):
+    client.post("/api/v1/users", json={"provider": "email", "email": email, "password": "pwd"})
+    resp = client.post("/api/v1/auth/login", json={"email": email, "password": "pwd"})
+    return resp.json()["data"]["access_token"]
+
+
+def test_root_and_health(client):
+    assert client.get("/").status_code == 200
+    resp = client.get("/api/v1/health")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == "ok"
+
+
+def test_last_login_set(client):
+    token = create_user_and_login(client, "login@example.com")
+    user_id = decode_access_token(token)
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = client.get(f"/api/v1/users/{user_id}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["last_login"] is not None
+
+
+def test_message_rate_limit(client):
+    token = create_user_and_login(client, "rate@example.com")
+    headers = {"Authorization": f"Bearer {token}"}
+    conv = client.post("/api/v1/conversations", headers=headers, json={}).json()["data"]
+    url = f"/api/v1/conversations/{conv['conversation_id']}/messages"
+    for _ in range(5):
+        assert client.post(url, headers=headers, json={"content": {"t": 1}, "message_type": "user"}).status_code == 200
+    resp = client.post(url, headers=headers, json={"content": {"t": 2}, "message_type": "user"})
+    assert resp.status_code == 429


### PR DESCRIPTION
## Summary
- add rate limiter for message creation
- track last login timestamp during authentication
- expose new helper in services
- document rate limiting and usage tracking
- provide future enhancement ideas
- test new behaviour and cover root and health routes

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886033b82c483278790cf196f79a425