### PR TITLE
Add refresh tokens and password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ limited. The `/auth/logout` endpoint now invalidates the provided token and
 | PATCH | `/api/v1/users/{user_id}` | Partially update a user |
 | DELETE | `/api/v1/users/{user_id}` | Delete a user |
 | GET | `/` | Returns a welcome message (not in the OpenAPI schema) |
-| POST | `/api/v1/auth/login` | Login and receive a token |
+| POST | `/api/v1/auth/login` | Login and receive access & refresh tokens |
 | POST | `/api/v1/auth/logout` | Logout using token |
 | POST | `/api/v1/auth/verify` | Verify token validity |
+| POST | `/api/v1/auth/refresh` | Refresh access token |
+| POST | `/api/v1/auth/request-reset` | Request password reset OTP |
+| POST | `/api/v1/auth/reset-password` | Reset password with OTP |
 | GET | `/api/v1/users/me` | Get current user |
 | PATCH | `/api/v1/users/me` | Update current user |
 | DELETE | `/api/v1/users/me` | Delete current user |

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -9,12 +9,16 @@ from app.core import (
     StandardResponse,
     verify_password,
     create_access_token,
+    create_refresh_token,
     decode_access_token,
+    decode_refresh_token,
     revoke_token,
+    revoke_refresh_token,
 )
+from app.core import settings
 from app.db.database import get_db
 from app.repositories import user as user_repo
-from app.schemas import LoginRequest, TokenResponse
+from app.schemas import LoginRequest, TokenResponse, UserUpdate
 from app.services import check_login_rate_limit
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -32,19 +36,25 @@ def login(credentials: LoginRequest, db: Session = Depends(get_db)) -> dict:
         logger.warning("Inactive/suspended login attempt for %s", credentials.email)
         raise HTTPException(status_code=403, detail="Account disabled")
     token = create_access_token(user.user_id)
+    refresh = create_refresh_token(user.user_id)
     user_repo.update_last_login(db, user)
     logger.info("User %s logged in", user.user_id)
-    return success(TokenResponse(access_token=token)).dict()
+    return success(TokenResponse(access_token=token, refresh_token=refresh)).dict()
 
 
 @router.post("/logout", response_model=StandardResponse, summary="Logout")
-def logout(authorization: str = Header(..., alias="Authorization")) -> dict:
+def logout(
+    authorization: str = Header(..., alias="Authorization"),
+    refresh_token: str | None = Header(None, alias="X-Refresh-Token"),
+) -> dict:
     token = authorization.replace("Bearer ", "")
     try:
         decode_access_token(token)
     except Exception:
         raise HTTPException(status_code=401, detail="Invalid token")
-    revoke_token(token)
+    revoke_token(token, settings.access_token_expire_minutes * 60)
+    if refresh_token:
+        revoke_refresh_token(refresh_token)
     logger.info("Token revoked")
     return success({"detail": "logout successful"}).dict()
 
@@ -58,3 +68,47 @@ def verify(authorization: str = Header(..., alias="Authorization")) -> dict:
         raise HTTPException(status_code=401, detail="Invalid token")
     logger.debug("Token for %s verified", user_id)
     return success({"user_id": str(user_id)}).dict()
+
+
+@router.post("/refresh", response_model=StandardResponse, summary="Refresh token")
+def refresh_token_endpoint(refresh_token: str = Header(..., alias="X-Refresh-Token")) -> dict:
+    try:
+        user_id = decode_refresh_token(refresh_token)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    new_access = create_access_token(user_id)
+    new_refresh = create_refresh_token(user_id)
+    revoke_refresh_token(refresh_token)
+    return success(TokenResponse(access_token=new_access, refresh_token=new_refresh)).dict()
+
+
+@router.post("/request-reset", response_model=StandardResponse, summary="Request password reset")
+def request_reset(data: dict, db: Session = Depends(get_db)) -> dict:
+    email = data.get("email")
+    if not email:
+        raise HTTPException(status_code=400, detail="Email required")
+    user = user_repo.get_user_by_email(db, email)
+    if not user:
+        return success({"detail": "reset requested"}).dict()
+    from app.services.password_reset import generate_otp
+    otp = generate_otp(email)
+    logger.info("Password reset requested for %s", email)
+    return success({"otp": otp}).dict()
+
+
+@router.post("/reset-password", response_model=StandardResponse, summary="Reset password")
+def reset_password(data: dict, db: Session = Depends(get_db)) -> dict:
+    email = data.get("email")
+    otp = data.get("otp")
+    new_password = data.get("new_password")
+    if not email or not otp or not new_password:
+        raise HTTPException(status_code=400, detail="Invalid request")
+    user = user_repo.get_user_by_email(db, email)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    from app.services.password_reset import verify_and_consume_otp
+    if not verify_and_consume_otp(email, otp):
+        raise HTTPException(status_code=400, detail="Invalid OTP")
+    user_repo.update_user(db, user, UserUpdate(password=new_password))
+    logger.info("Password reset for %s", email)
+    return success({"detail": "password updated"}).dict()

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -6,8 +6,11 @@ from .security import (
     hash_password,
     verify_password,
     create_access_token,
+    create_refresh_token,
     decode_access_token,
+    decode_refresh_token,
     revoke_token,
+    revoke_refresh_token,
 )
 
 __all__ = [
@@ -18,5 +21,8 @@ __all__ = [
     "verify_password",
     "create_access_token",
     "decode_access_token",
+    "decode_refresh_token",
     "revoke_token",
+    "create_refresh_token",
+    "revoke_refresh_token",
 ]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,5 +8,7 @@ class Settings(BaseSettings):
     secret_key: str = "secret"
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 60
+    refresh_token_expire_days: int = 7
+    redis_url: str = "redis://localhost:6379/0"
 
 settings = Settings()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta
 from uuid import UUID
+import time
 
 import jwt
-from typing import Set
+import redis
+from typing import Set, Dict
 from passlib.context import CryptContext
 
 from app.core.config import settings
@@ -10,16 +12,82 @@ from app.core.config import settings
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 _revoked_tokens: Set[str] = set()
+_refresh_tokens: Dict[str, float] = {}
+
+redis_client = None
+if hasattr(settings, "redis_url") and settings.redis_url:
+    try:
+        redis_client = redis.from_url(settings.redis_url, decode_responses=True)
+        # test connection
+        redis_client.ping()
+    except Exception:
+        redis_client = None
 
 
-def revoke_token(token: str) -> None:
+def revoke_token(token: str, expires: int) -> None:
     """Mark a token as revoked."""
+    global redis_client
+    if redis_client:
+        try:
+            redis_client.setex(f"revoked:{token}", expires, "1")
+            return
+        except Exception:
+            redis_client = None
     _revoked_tokens.add(token)
 
 
 def is_token_revoked(token: str) -> bool:
     """Check whether the given token has been revoked."""
+    if redis_client:
+        return redis_client.exists(f"revoked:{token}") == 1
     return token in _revoked_tokens
+
+
+def create_refresh_token(user_id: UUID) -> str:
+    """Generate a refresh token and store it."""
+    expire = datetime.utcnow() + timedelta(days=settings.refresh_token_expire_days)
+    payload = {"sub": str(user_id), "exp": expire, "type": "refresh"}
+    token = jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
+    ttl = int((expire - datetime.utcnow()).total_seconds())
+    global redis_client
+    if redis_client:
+        try:
+            redis_client.setex(f"refresh:{token}", ttl, str(user_id))
+        except Exception:
+            redis_client = None
+            _refresh_tokens[token] = time.time() + ttl
+    else:
+        _refresh_tokens[token] = time.time() + ttl
+    return token
+
+
+def revoke_refresh_token(token: str) -> None:
+    global redis_client
+    if redis_client:
+        try:
+            redis_client.delete(f"refresh:{token}")
+            return
+        except Exception:
+            redis_client = None
+    _refresh_tokens.pop(token, None)
+
+
+def decode_refresh_token(token: str) -> UUID:
+    global redis_client
+    if redis_client:
+        try:
+            exists = redis_client.exists(f"refresh:{token}") == 1
+        except Exception:
+            redis_client = None
+            expires_at = _refresh_tokens.get(token)
+            exists = expires_at and expires_at > time.time()
+    else:
+        expires_at = _refresh_tokens.get(token)
+        exists = expires_at and expires_at > time.time()
+    if not exists:
+        raise jwt.InvalidTokenError("Token revoked")
+    data = jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    return UUID(data["sub"])
 
 def hash_password(password: str) -> str:
     """Hash a plain text password."""
@@ -31,10 +99,12 @@ def verify_password(plain_password: str, password_hash: str) -> bool:
     return pwd_context.verify(plain_password, password_hash)
 
 
-def create_access_token(user_id: UUID) -> str:
+def create_access_token(user_id: UUID, expires_delta: timedelta | None = None) -> str:
     """Generate a JWT access token for the given user."""
-    expire = datetime.utcnow() + timedelta(minutes=settings.access_token_expire_minutes)
-    payload = {"sub": str(user_id), "exp": expire}
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=settings.access_token_expire_minutes)
+    )
+    payload = {"sub": str(user_id), "exp": expire, "type": "access"}
     token = jwt.encode(payload, settings.secret_key, algorithm=settings.jwt_algorithm)
     return token
 
@@ -44,4 +114,6 @@ def decode_access_token(token: str) -> UUID:
     if is_token_revoked(token):
         raise jwt.InvalidTokenError("Token revoked")
     data = jwt.decode(token, settings.secret_key, algorithms=[settings.jwt_algorithm])
+    if data.get("type") != "access":
+        raise jwt.InvalidTokenError("Invalid token type")
     return UUID(data["sub"])

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -13,6 +13,7 @@ class LoginRequest(BaseModel):
 
 class TokenResponse(BaseModel):
     access_token: str
+    refresh_token: str
 
 __all__ = [
     "ChatRequest",

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -6,10 +6,13 @@ from .rate_limiter import (
     check_login_rate_limit,
     check_message_rate_limit,
 )
+from .password_reset import generate_otp, verify_and_consume_otp
 
 __all__ = [
     "chat_with_openai",
     "check_chat_rate_limit",
     "check_login_rate_limit",
     "check_message_rate_limit",
+    "generate_otp",
+    "verify_and_consume_otp",
 ]

--- a/app/services/password_reset.py
+++ b/app/services/password_reset.py
@@ -1,0 +1,25 @@
+import secrets
+import time
+from typing import Dict, Tuple
+
+_otp_store: Dict[str, Tuple[str, float]] = {}
+
+OTP_TTL = 300  # seconds
+
+
+def generate_otp(email: str) -> str:
+    otp = secrets.token_hex(3)
+    expires = time.time() + OTP_TTL
+    _otp_store[email] = (otp, expires)
+    return otp
+
+
+def verify_and_consume_otp(email: str, otp: str) -> bool:
+    saved = _otp_store.get(email)
+    if not saved:
+        return False
+    code, expires = saved
+    if time.time() > expires or code != otp:
+        return False
+    del _otp_store[email]
+    return True

--- a/tests/test_auth_api.py
+++ b/tests/test_auth_api.py
@@ -1,0 +1,94 @@
+import os
+import sys
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.database import Base, get_db
+from app.core import create_access_token
+from app.core.security import decode_access_token
+
+@pytest.fixture
+def client():
+    engine = create_engine("sqlite:///./test_auth.db", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    os.remove("test_auth.db")
+
+
+def create_user(client, email="edge@example.com"):
+    client.post("/api/v1/users", json={"provider": "email", "email": email, "password": "pwd"})
+
+
+def login(client, email="edge@example.com", password="pwd"):
+    return client.post("/api/v1/auth/login", json={"email": email, "password": password})
+
+
+def test_invalid_credentials(client):
+    create_user(client)
+    resp = login(client, password="bad")
+    assert resp.status_code == 401
+
+
+def test_logout_invalidates_token(client):
+    create_user(client)
+    tokens = login(client).json()["data"]
+    token = tokens["access_token"]
+    refresh = tokens["refresh_token"]
+    headers = {"Authorization": f"Bearer {token}", "X-Refresh-Token": refresh}
+    client.post("/api/v1/auth/logout", headers=headers)
+    resp = client.post("/api/v1/auth/verify", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_refresh_flow(client):
+    create_user(client)
+    data = login(client).json()["data"]
+    refresh = data["refresh_token"]
+    resp = client.post("/api/v1/auth/refresh", headers={"X-Refresh-Token": refresh})
+    assert resp.status_code == 200
+    new_refresh = resp.json()["data"]["refresh_token"]
+    # old refresh token should be revoked
+    bad = client.post("/api/v1/auth/refresh", headers={"X-Refresh-Token": refresh})
+    assert bad.status_code == 401
+    assert "access_token" in resp.json()["data"]
+
+
+def test_expired_token(client):
+    create_user(client)
+    from datetime import timedelta
+    login_data = login(client).json()["data"]
+    user_id = decode_access_token(login_data["access_token"])
+    token = create_access_token(user_id, expires_delta=timedelta(seconds=-1))
+    resp = client.post("/api/v1/auth/verify", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+def test_password_reset_flow(client):
+    email = "reset@example.com"
+    create_user(client, email=email)
+    resp = client.post("/api/v1/auth/request-reset", json={"email": email})
+    otp = resp.json()["data"]["otp"]
+    reset = client.post("/api/v1/auth/reset-password", json={"email": email, "otp": otp, "new_password": "new"})
+    assert reset.status_code == 200
+    login_resp = client.post("/api/v1/auth/login", json={"email": email, "password": "new"})
+    assert login_resp.status_code == 200


### PR DESCRIPTION
## Summary
- introduce Redis-backed revocation with in-memory fallback
- add refresh tokens and refresh endpoint
- implement OTP password reset flow
- update authentication docs with new routes
- provide comprehensive auth tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860a9d9640832792c30088cd7c2983