### PR TITLE
Enhance chat endpoint with conversation memory and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ limited. The `/auth/logout` endpoint now invalidates the provided token and
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | GET | `/api/v1/health` | Returns `{"status": "ok"}` |
-| POST | `/api/v1/chat` | Chat with OpenAI GPT-4. Body: `{"message": "<text>"}`. Returns `{"response": "<reply>"}` |
+| POST | `/api/v1/chat` | Chat with OpenAI GPT-4. Body: `{"message": "<text>", "conversation_id": "<uuid>"}`. Returns `{"response": "<reply>", "tokens": <n>}` |
 | GET | `/api/v1/users` | List users with pagination and search |
 | POST | `/api/v1/users` | Create a new user |
 | GET | `/api/v1/users/{user_id}` | Retrieve a user by ID |

--- a/app/main.py
+++ b/app/main.py
@@ -33,7 +33,12 @@ async def handle_db_exceptions(request: Request, exc: SQLAlchemyError):
 @app.exception_handler(HTTPException)
 async def handle_http_exceptions(request: Request, exc: HTTPException):
     """Return a consistent JSON structure for HTTP errors."""
-    resp = success(message=exc.detail, code=exc.status_code)
+    message = exc.detail
+    data = None
+    if isinstance(exc.detail, dict):
+        message = exc.detail.get("message", "Error")
+        data = exc.detail.get("data")
+    resp = success(message=message, data=data, code=exc.status_code)
     return JSONResponse(status_code=exc.status_code, content=resp.dict())
 
 

--- a/app/schemas/chat.py
+++ b/app/schemas/chat.py
@@ -1,7 +1,10 @@
+from typing import Optional
+from uuid import UUID
 from pydantic import BaseModel
 
 class ChatRequest(BaseModel):
     message: str
+    conversation_id: Optional[UUID] = None
 
 class ChatResponse(BaseModel):
     response: str

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,6 +1,6 @@
 """Service utilities for the API."""
 
-from .llm import chat_with_openai
+from .llm import chat_with_openai, chat_with_openai_history
 from .rate_limiter import (
     check_chat_rate_limit,
     check_login_rate_limit,
@@ -16,6 +16,7 @@ from .billing import charge_plan
 
 __all__ = [
     "chat_with_openai",
+    "chat_with_openai_history",
     "check_chat_rate_limit",
     "check_login_rate_limit",
     "check_message_rate_limit",

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,7 +1,7 @@
 """Service wrappers for the language model provider."""
 
 import logging
-from typing import Any
+from typing import Any, List, Dict
 
 from openai import OpenAI, OpenAIError
 
@@ -37,3 +37,21 @@ def chat_with_openai(message: str) -> tuple[str, int]:
     except OpenAIError as exc:  # pragma: no cover - API errors
         logger.exception("OpenAI API request failed")
         raise RuntimeError("OpenAI API request failed") from exc
+
+
+def chat_with_openai_history(messages: List[Dict[str, str]]) -> tuple[str, int]:
+    """Send conversation history to OpenAI GPT-4."""
+    try:
+        response: Any = openai_client.chat.completions.create(
+            model="gpt-4",
+            messages=messages,
+        )
+        tokens = 0
+        try:
+            tokens = int(response.usage.total_tokens)
+        except Exception:  # pragma: no cover - optional
+            tokens = 0
+        return response.choices[0].message.content, tokens
+    except OpenAIError as exc:  # pragma: no cover - API errors
+        logger.exception("OpenAI API request failed")
+        raise RuntimeError(str(exc)) from exc

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.database import Base, get_db
+
+
+@pytest.fixture
+def client():
+    engine = create_engine("sqlite:///./test_chat.db", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    os.remove("test_chat.db")
+
+
+def create_user_and_login(client):
+    client.post("/api/v1/users", json={"provider": "email", "email": "chat@example.com", "password": "pwd"})
+    resp = client.post("/api/v1/auth/login", json={"email": "chat@example.com", "password": "pwd"})
+    return resp.json()["data"]["access_token"]
+
+
+def test_chat_with_memory(client, monkeypatch):
+    token = create_user_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    conv = client.post("/api/v1/conversations", headers=headers, json={}).json()["data"]
+    import app.api.v1.endpoints.chat as chat_ep
+    monkeypatch.setattr(chat_ep, "check_chat_rate_limit", lambda _u: None)
+    monkeypatch.setattr(chat_ep, "chat_with_openai_history", lambda m: ("hi", 2))
+    resp = client.post("/api/v1/chat", headers=headers, json={"message": "hello", "conversation_id": conv["conversation_id"]})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["response"] == "hi"
+    msgs = client.get(f"/api/v1/conversations/{conv['conversation_id']}/messages", headers=headers).json()["data"]
+    assert len(msgs) == 2
+
+
+def test_chat_openai_failure(client, monkeypatch):
+    token = create_user_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    conv = client.post("/api/v1/conversations", headers=headers, json={}).json()["data"]
+    import app.api.v1.endpoints.chat as chat_ep
+    def fail(_):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(chat_ep, "chat_with_openai_history", fail)
+    resp = client.post("/api/v1/chat", headers=headers, json={"message": "hello", "conversation_id": conv["conversation_id"]})
+    assert resp.status_code == 502
+    assert resp.json()["data"]["source"] == "openai"
+
+
+def test_chat_token_quota(client, monkeypatch):
+    token = create_user_and_login(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    conv = client.post("/api/v1/conversations", headers=headers, json={}).json()["data"]
+    import app.core.plans as plans
+    plans.PLANS["free"]["daily_tokens"] = 2
+    import app.api.v1.endpoints.chat as chat_ep
+    monkeypatch.setattr(chat_ep, "check_chat_rate_limit", lambda _u: None)
+    monkeypatch.setattr(chat_ep, "chat_with_openai_history", lambda m: ("ok", 1))
+    for _ in range(2):
+        resp = client.post("/api/v1/chat", headers=headers, json={"message": "hello", "conversation_id": conv["conversation_id"]})
+        assert resp.status_code == 200
+    resp = client.post("/api/v1/chat", headers=headers, json={"message": "again", "conversation_id": conv["conversation_id"]})
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- connect `/chat` endpoint with conversation history
- record messages and tokens to enforce quotas
- expose OpenAI failures with source and reason
- handle HTTPException details consistently
- cover new chat logic in tests
- document updated `/chat` endpoint usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688612cc66288327ae1c056692422e3b