### PR TITLE
Add file upload quotas and billing stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,4 +142,5 @@ authenticated user must have `is_admin` enabled.
 - Add background job queue for long running tasks
 - Implement OAuth providers for enterprise authentication
 - Provide OpenAPI schemas for client code generation
+- Integrate payment processing in `charge_plan` to bill upgrades
 

--- a/app/api/v1/endpoints/uploads.py
+++ b/app/api/v1/endpoints/uploads.py
@@ -1,15 +1,27 @@
-from fastapi import APIRouter, UploadFile, File, Depends
+from datetime import date
+from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
+from sqlalchemy.orm import Session
 from app.api.deps import get_current_user
-from app.core import success, StandardResponse
+from app.db.database import get_db
+from app.core import success, StandardResponse, PLANS
 from app.services import upload_file_obj
+from app.repositories import usage as usage_repo
 
 router = APIRouter(prefix="/uploads", tags=["uploads"])
+
 
 @router.post("", response_model=StandardResponse, summary="Upload file")
 def upload_file(
     file: UploadFile = File(...),
     current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
-    url = upload_file_obj(file)
-    return success({"url": url}).dict()
+    plan = PLANS.get(current_user.plan, PLANS["free"])
+    daily = usage_repo.get_daily_usage(db, current_user.user_id, date.today())
+    uploads = daily.file_uploads if daily and daily.file_uploads is not None else 0
+    if uploads >= plan.get("max_file_uploads", 0):
+        raise HTTPException(status_code=403, detail="Upgrade required")
 
+    url = upload_file_obj(file)
+    usage_repo.increment_file_uploads(db, current_user.user_id, date.today())
+    return success({"url": url}).dict()

--- a/app/services/billing.py
+++ b/app/services/billing.py
@@ -9,3 +9,4 @@ def charge_plan(user_id: str, plan: str) -> None:
     """Pretend to charge the user for the new plan."""
     logger.info("Pretend charging %s for plan %s", user_id, plan)
     # TODO: Integrate Stripe or Razorpay here
+    return None


### PR DESCRIPTION
## Summary
- enforce file-upload quota on `/uploads`
- track daily uploads when files are stored
- remove file count checks from message creation
- stub `charge_plan()` for future payment integration
- document upcoming billing flow
- test upload quota enforcement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688630b7d2ec8327a13cb0561a46c98b