### PR TITLE
Add moderation and streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ limited. The `/auth/logout` endpoint now invalidates the provided token and
 | Method | Path | Description |
 | ------ | ---- | ----------- |
 | GET | `/api/v1/health` | Returns `{"status": "ok"}` |
-| POST | `/api/v1/chat` | Chat with OpenAI GPT-4. Body: `{"message": "<text>", "conversation_id": "<uuid>"}`. Returns `{"response": "<reply>", "tokens": <n>}` |
+| POST | `/api/v1/chat` | Chat with OpenAI GPT-4. Body: `{"message": "<text>", "conversation_id": "<uuid>"}`. Add `?stream=true` to stream tokens as they are generated. |
 | GET | `/api/v1/users` | List users with pagination and search |
 | POST | `/api/v1/users` | Create a new user |
 | GET | `/api/v1/users/{user_id}` | Retrieve a user by ID |
@@ -116,10 +116,13 @@ limited. The `/auth/logout` endpoint now invalidates the provided token and
 | POST | `/api/v1/admin/users` | Admin create user |
 | PATCH | `/api/v1/admin/users/{user_id}` | Admin update user |
 | DELETE | `/api/v1/admin/users/{user_id}` | Admin delete user |
+| POST | `/api/v1/moderation/stage-in` | Stage incoming message |
+| POST | `/api/v1/moderation/stage-out` | Stage outgoing message |
+| GET | `/api/v1/moderation` | List staged messages |
 
-The message routes above store conversation history. They are separate from the
-`/chat` endpoint which streams a single prompt to the language model without
-creating conversation records.
+The message routes above store conversation history. The `/chat` endpoint can
+also attach to a conversation when a `conversation_id` is provided, otherwise it
+streams a single prompt without persisting any messages.
 
 Plan limits restrict how many conversations a user may keep, how many messages
 they can send per day and the total GPT tokens allowed each day. Exceeding

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -10,6 +10,7 @@ from app.api.v1.endpoints import (
     message_router,
     uploads,
     admin,
+    moderation,
 )
 
 api_router = APIRouter()
@@ -22,3 +23,4 @@ api_router.include_router(conversations.router)
 api_router.include_router(message_router)
 api_router.include_router(uploads.router)
 api_router.include_router(admin.router)
+api_router.include_router(moderation.router)

--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -6,6 +6,7 @@ from .plans import router as plans_router
 from .conversations import router as conversations_router, message_router
 from .uploads import router as uploads_router
 from .admin import router as admin_router
+from .moderation import router as moderation_router
 
 __all__ = [
     "auth_router",
@@ -17,4 +18,5 @@ __all__ = [
     "message_router",
     "uploads_router",
     "admin_router",
+    "moderation_router",
 ]

--- a/app/api/v1/endpoints/chat.py
+++ b/app/api/v1/endpoints/chat.py
@@ -1,13 +1,17 @@
 import logging
 from datetime import date
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.concurrency import run_in_threadpool
+from starlette.responses import StreamingResponse
+from starlette.background import BackgroundTask
+from starlette.concurrency import iterate_in_threadpool
 
 from app.core import success, StandardResponse
 from app.db.database import get_db
 from app.schemas.chat import ChatRequest
-from app.services.llm import chat_with_openai_history
+from app.services.llm import chat_with_openai_history, stream_openai_history
 from app.services import check_chat_rate_limit
 from app.core import PLANS
 from app.repositories import usage as usage_repo
@@ -24,7 +28,8 @@ async def chat(
     request: ChatRequest,
     current_user = Depends(get_current_user),
     db=Depends(get_db),
-) -> dict:
+    stream: bool = False,
+) -> dict | StreamingResponse:
     """Proxy a message to the language model with plan enforcement."""
     logger.info("Chat request from %s", current_user.user_id)
 
@@ -64,36 +69,77 @@ async def chat(
             history.append({"role": role, "content": text})
     history.append({"role": "user", "content": request.message})
 
-    try:
-        content, tokens = await run_in_threadpool(chat_with_openai_history, history)
-    except RuntimeError as exc:  # pragma: no cover - LLM errors
-        logger.exception("LLM request failed")
-        raise HTTPException(
-            status_code=502,
-            detail={"message": "OpenAI request failed", "data": {"source": "openai", "reason": str(exc)}},
-        ) from exc
-    except Exception as exc:  # pragma: no cover - unexpected errors
-        logger.exception("Unexpected chat failure")
-        raise HTTPException(
-            status_code=500,
-            detail={"message": "Internal error", "data": {"source": "server", "reason": "unexpected"}},
-        ) from exc
+    if stream:
+        state: dict[str, Any] = {}
+        def finalize() -> None:
+            if request.conversation_id:
+                message_repo.create_message(
+                    db,
+                    request.conversation_id,
+                    current_user.user_id,
+                    {"text": request.message},
+                    "user",
+                )
+                message_repo.create_message(
+                    db,
+                    request.conversation_id,
+                    None,
+                    {"text": state.get("response", "")},
+                    "ai",
+                )
+            usage_repo.increment_message_count(db, current_user.user_id, date.today())
+            usage_repo.increment_token_count(db, current_user.user_id, date.today(), state.get("tokens", 0))
 
-    if request.conversation_id:
-        message_repo.create_message(
-            db,
-            request.conversation_id,
-            current_user.user_id,
-            {"text": request.message},
-            "user",
-        )
-        message_repo.create_message(
-            db,
-            request.conversation_id,
-            None,
-            {"text": content},
-            "ai",
-        )
-    usage_repo.increment_message_count(db, current_user.user_id, date.today())
-    usage_repo.increment_token_count(db, current_user.user_id, date.today(), tokens)
-    return success({"response": content, "tokens": tokens}).dict()
+        try:
+            generator = stream_openai_history(history, state)
+            return StreamingResponse(
+                iterate_in_threadpool(generator),
+                background=BackgroundTask(finalize),
+                media_type="text/plain",
+            )
+        except RuntimeError as exc:
+            logger.exception("LLM request failed")
+            raise HTTPException(
+                status_code=502,
+                detail={"message": "OpenAI request failed", "data": {"source": "openai", "reason": str(exc)}},
+            ) from exc
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logger.exception("Unexpected chat failure")
+            raise HTTPException(
+                status_code=500,
+                detail={"message": "Internal error", "data": {"source": "server", "reason": "unexpected"}},
+            ) from exc
+    else:
+        try:
+            content, tokens = await run_in_threadpool(chat_with_openai_history, history)
+        except RuntimeError as exc:  # pragma: no cover - LLM errors
+            logger.exception("LLM request failed")
+            raise HTTPException(
+                status_code=502,
+                detail={"message": "OpenAI request failed", "data": {"source": "openai", "reason": str(exc)}},
+            ) from exc
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logger.exception("Unexpected chat failure")
+            raise HTTPException(
+                status_code=500,
+                detail={"message": "Internal error", "data": {"source": "server", "reason": "unexpected"}},
+            ) from exc
+
+        if request.conversation_id:
+            message_repo.create_message(
+                db,
+                request.conversation_id,
+                current_user.user_id,
+                {"text": request.message},
+                "user",
+            )
+            message_repo.create_message(
+                db,
+                request.conversation_id,
+                None,
+                {"text": content},
+                "ai",
+            )
+        usage_repo.increment_message_count(db, current_user.user_id, date.today())
+        usage_repo.increment_token_count(db, current_user.user_id, date.today(), tokens)
+        return success({"response": content, "tokens": tokens}).dict()

--- a/app/api/v1/endpoints/moderation.py
+++ b/app/api/v1/endpoints/moderation.py
@@ -1,0 +1,34 @@
+import logging
+from uuid import uuid4
+from typing import List
+
+from fastapi import APIRouter
+
+from app.core import success, StandardResponse
+
+router = APIRouter(prefix="/moderation", tags=["moderation"])
+
+logger = logging.getLogger(__name__)
+
+_STAGED: List[dict] = []
+
+
+@router.post("/stage-in", response_model=StandardResponse, summary="Stage incoming message")
+def stage_in(message: str) -> dict:
+    item = {"id": str(uuid4()), "direction": "in", "message": message}
+    _STAGED.append(item)
+    logger.info("Staged incoming message %s", item["id"])
+    return success(item).dict()
+
+
+@router.post("/stage-out", response_model=StandardResponse, summary="Stage outgoing message")
+def stage_out(message: str) -> dict:
+    item = {"id": str(uuid4()), "direction": "out", "message": message}
+    _STAGED.append(item)
+    logger.info("Staged outgoing message %s", item["id"])
+    return success(item).dict()
+
+
+@router.get("", response_model=StandardResponse, summary="List staged messages")
+def list_items() -> dict:
+    return success(list(_STAGED)).dict()

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,6 +1,6 @@
 """Service utilities for the API."""
 
-from .llm import chat_with_openai, chat_with_openai_history
+from .llm import chat_with_openai, chat_with_openai_history, stream_openai_history
 from .rate_limiter import (
     check_chat_rate_limit,
     check_login_rate_limit,
@@ -19,6 +19,7 @@ from .storage import upload_file_obj
 __all__ = [
     "chat_with_openai",
     "chat_with_openai_history",
+    "stream_openai_history",
     "check_chat_rate_limit",
     "check_login_rate_limit",
     "check_message_rate_limit",

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -1,7 +1,7 @@
 """Service wrappers for the language model provider."""
 
 import logging
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Generator
 
 from openai import OpenAI, OpenAIError
 
@@ -52,6 +52,37 @@ def chat_with_openai_history(messages: List[Dict[str, str]]) -> tuple[str, int]:
         except Exception:  # pragma: no cover - optional
             tokens = 0
         return response.choices[0].message.content, tokens
+    except OpenAIError as exc:  # pragma: no cover - API errors
+        logger.exception("OpenAI API request failed")
+        raise RuntimeError(str(exc)) from exc
+
+
+def stream_openai_history(
+    messages: List[Dict[str, str]],
+    state: dict[str, Any],
+) -> Generator[str, None, None]:
+    """Stream conversation history to OpenAI GPT-4."""
+    try:
+        response: Any = openai_client.chat.completions.create(
+            model="gpt-4",
+            messages=messages,
+            stream=True,
+        )
+        collected = []
+        tokens = 0
+        for chunk in response:
+            if hasattr(chunk, "choices"):
+                delta = chunk.choices[0].delta
+                if delta and delta.content:
+                    collected.append(delta.content)
+                    yield delta.content
+            if getattr(chunk, "usage", None):
+                try:
+                    tokens = int(chunk.usage.total_tokens)
+                except Exception:  # pragma: no cover - optional
+                    tokens = 0
+        state["tokens"] = tokens
+        state["response"] = "".join(collected)
     except OpenAIError as exc:  # pragma: no cover - API errors
         logger.exception("OpenAI API request failed")
         raise RuntimeError(str(exc)) from exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ dotenv
 passlib[bcrypt]
 pydantic-settings
 PyJWT
+python-multipart


### PR DESCRIPTION
## Summary
- add python-multipart dependency for uploads
- provide moderation staging endpoints
- enable optional streaming for chat responses
- expose new streaming helper in services
- document new endpoints in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886324d439883279be1b5eabc16afda