### PR TITLE
Implement upload management

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ limited. The `/auth/logout` endpoint now invalidates the provided token and
 | PATCH | `/api/v1/messages/{message_id}` | Update message |
 | DELETE | `/api/v1/messages/{message_id}` | Delete message |
 | POST | `/api/v1/uploads` | Upload file |
+| GET | `/api/v1/uploads` | List user uploads |
+| DELETE | `/api/v1/uploads/{upload_id}` | Delete uploaded file |
 | GET | `/api/v1/admin/users` | Admin list users |
 | POST | `/api/v1/admin/users` | Admin create user |
 | PATCH | `/api/v1/admin/users/{user_id}` | Admin update user |

--- a/alembic/versions/ae7b21c093c1_add_uploads_table.py
+++ b/alembic/versions/ae7b21c093c1_add_uploads_table.py
@@ -1,0 +1,27 @@
+"""add uploads table"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'ae7b21c093c1'
+down_revision: Union[str, Sequence[str], None] = 'ba29ad6e9013'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'uploads',
+        sa.Column('upload_id', sa.UUID(), primary_key=True),
+        sa.Column('user_id', sa.UUID(), sa.ForeignKey('users.user_id'), nullable=False),
+        sa.Column('bucket', sa.String(), nullable=False),
+        sa.Column('key', sa.String(), nullable=False),
+        sa.Column('content_type', sa.String(), nullable=True),
+        sa.Column('size', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('uploads')

--- a/app/api/v1/endpoints/uploads.py
+++ b/app/api/v1/endpoints/uploads.py
@@ -1,11 +1,17 @@
 from datetime import date
+from uuid import UUID
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
 from sqlalchemy.orm import Session
 from app.api.deps import get_current_user
 from app.db.database import get_db
-from app.core import success, StandardResponse, PLANS
-from app.services import upload_file_obj
+from app.core import success, StandardResponse, PLANS, settings
+from app.services import upload_file_obj, get_file_url, delete_file
 from app.repositories import usage as usage_repo
+from app.repositories import upload as upload_repo
+from app.schemas import UploadRead
+
+MAX_FILE_SIZE = 10 * 1024 * 1024  # 10MB
+ALLOWED_TYPES = {"image/png", "image/jpeg", "text/plain", "application/pdf"}
 
 router = APIRouter(prefix="/uploads", tags=["uploads"])
 
@@ -22,6 +28,52 @@ def upload_file(
     if uploads >= plan.get("max_file_uploads", 0):
         raise HTTPException(status_code=403, detail="Upgrade required")
 
-    url = upload_file_obj(file)
+    data = file.file.read()
+    size = len(data)
+    if size > MAX_FILE_SIZE:
+        raise HTTPException(status_code=400, detail="File too large")
+    if file.content_type not in ALLOWED_TYPES:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+    file.file.seek(0)
+    key, size = upload_file_obj(file)
+    record = upload_repo.create_upload(
+        db,
+        current_user.user_id,
+        settings.minio_bucket,
+        key,
+        file.content_type,
+        size,
+    )
+    url = get_file_url(key)
     usage_repo.increment_file_uploads(db, current_user.user_id, date.today())
-    return success({"url": url}).dict()
+    payload = {"url": url, "upload_id": record.upload_id}
+    return success(payload).dict()
+
+
+@router.get("", response_model=StandardResponse, summary="List uploads")
+def list_uploads(
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+    skip: int = 0,
+    limit: int = 100,
+) -> list[UploadRead]:
+    uploads = upload_repo.list_uploads(db, current_user.user_id, skip=skip, limit=limit)
+    payload = [
+        UploadRead.model_validate(u).model_copy(update={"url": get_file_url(u.key)})
+        for u in uploads
+    ]
+    return success(payload).dict()
+
+
+@router.delete("/{upload_id}", response_model=StandardResponse, summary="Delete upload")
+def delete_upload(
+    upload_id: UUID,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    upload = upload_repo.get_upload(db, upload_id)
+    if not upload or upload.user_id != current_user.user_id:
+        raise HTTPException(status_code=404, detail="File not found")
+    delete_file(upload.key)
+    upload_repo.delete_upload(db, upload)
+    return success({"deleted": str(upload_id)}).dict()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,5 +2,6 @@ from .user import User
 from .conversation import Conversation
 from .message import Message
 from .usage import Usage
+from .upload import Upload
 
-__all__ = ["User", "Conversation", "Message", "Usage"]
+__all__ = ["User", "Conversation", "Message", "Usage", "Upload"]

--- a/app/models/upload.py
+++ b/app/models/upload.py
@@ -1,0 +1,16 @@
+import uuid
+from sqlalchemy import Column, String, DateTime, Integer, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+from app.db.database import Base
+
+class Upload(Base):
+    __tablename__ = "uploads"
+
+    upload_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.user_id"), nullable=False)
+    bucket = Column(String, nullable=False)
+    key = Column(String, nullable=False)
+    content_type = Column(String, nullable=True)
+    size = Column(Integer, nullable=False)
+    created_at = Column(DateTime, server_default=func.now())

--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -1,3 +1,7 @@
 from . import user
+from . import conversation
+from . import message
+from . import usage
+from . import upload
 
-__all__ = ["user"]
+__all__ = ["user", "conversation", "message", "usage", "upload"]

--- a/app/repositories/upload.py
+++ b/app/repositories/upload.py
@@ -1,0 +1,39 @@
+from typing import List, Optional
+from uuid import UUID
+from sqlalchemy.orm import Session
+from app.models.upload import Upload
+
+
+def create_upload(db: Session, user_id: UUID, bucket: str, key: str, content_type: str | None, size: int) -> Upload:
+    upload = Upload(
+        user_id=user_id,
+        bucket=bucket,
+        key=key,
+        content_type=content_type,
+        size=size,
+    )
+    db.add(upload)
+    db.commit()
+    db.refresh(upload)
+    return upload
+
+
+def list_uploads(db: Session, user_id: UUID, skip: int = 0, limit: int = 100) -> List[Upload]:
+    return (
+        db.query(Upload)
+        .filter(Upload.user_id == user_id)
+        .order_by(Upload.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def get_upload(db: Session, upload_id: UUID) -> Optional[Upload]:
+    return db.query(Upload).filter(Upload.upload_id == upload_id).first()
+
+
+def delete_upload(db: Session, upload: Upload) -> Upload:
+    db.delete(upload)
+    db.commit()
+    return upload

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -3,6 +3,7 @@ from .user import UserCreate, UserRead, UserUpdate
 from .conversation import ConversationCreate, ConversationRead, ConversationUpdate
 from .message import MessageCreate, MessageRead, MessageUpdate
 from .usage import UsageRead
+from .upload import UploadRead
 from pydantic import BaseModel
 
 
@@ -28,6 +29,7 @@ __all__ = [
     "MessageRead",
     "MessageUpdate",
     "UsageRead",
+    "UploadRead",
     "LoginRequest",
     "TokenResponse",
 ]

--- a/app/schemas/upload.py
+++ b/app/schemas/upload.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from uuid import UUID
+from typing import Optional
+from pydantic import BaseModel, ConfigDict
+
+class UploadRead(BaseModel):
+    upload_id: UUID
+    bucket: str
+    key: str
+    content_type: Optional[str] = None
+    size: int
+    created_at: Optional[datetime] = None
+    url: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -14,7 +14,7 @@ from .password_reset import (
     verify_email_token,
 )
 from .billing import charge_plan
-from .storage import upload_file_obj
+from .storage import upload_file_obj, get_file_url, delete_file
 
 __all__ = [
     "chat_with_openai",
@@ -30,4 +30,6 @@ __all__ = [
     "verify_email_token",
     "charge_plan",
     "upload_file_obj",
+    "get_file_url",
+    "delete_file",
 ]

--- a/tests/test_conversation_api.py
+++ b/tests/test_conversation_api.py
@@ -229,7 +229,8 @@ def test_file_upload_and_message(client, monkeypatch):
     conv = client.post("/api/v1/conversations", headers=headers, json={}).json()["data"]
     import app.api.v1.endpoints.uploads as upload_ep
 
-    monkeypatch.setattr(upload_ep, "upload_file_obj", lambda f: "http://minio/test.txt")
+    monkeypatch.setattr(upload_ep, "upload_file_obj", lambda f: ("test.txt", 1))
+    monkeypatch.setattr(upload_ep, "get_file_url", lambda k: f"http://minio/{k}")
     import app.core.plans as plans
 
     plans.PLANS["free"]["max_file_uploads"] = 1

--- a/tests/test_upload_api.py
+++ b/tests/test_upload_api.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import app
+from app.db.database import Base, get_db
+
+
+@pytest.fixture
+def client():
+    engine = create_engine("sqlite:///./test_upload.db", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+    os.remove("test_upload.db")
+
+
+def create_auth(client):
+    client.post("/api/v1/users", json={"provider": "email", "email": "u@e.com", "password": "pwd"})
+    token = client.post("/api/v1/auth/login", json={"email": "u@e.com", "password": "pwd"}).json()["data"]["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_list_and_delete_upload(client, monkeypatch):
+    headers = create_auth(client)
+    import app.api.v1.endpoints.uploads as upload_ep
+
+    monkeypatch.setattr(upload_ep, "upload_file_obj", lambda f: ("k1", 1))
+    monkeypatch.setattr(upload_ep, "get_file_url", lambda k: f"http://minio/{k}")
+    monkeypatch.setattr(upload_ep, "delete_file", lambda k: None)
+    import app.core.plans as plans
+    plans.PLANS["free"]["max_file_uploads"] = 1
+
+    resp = client.post("/api/v1/uploads", headers=headers, files={"file": ("t.txt", b"x", "text/plain")})
+    uid = resp.json()["data"]["upload_id"]
+
+    lst = client.get("/api/v1/uploads", headers=headers)
+    assert lst.status_code == 200
+    assert len(lst.json()["data"]) == 1
+
+    del_resp = client.delete(f"/api/v1/uploads/{uid}", headers=headers)
+    assert del_resp.status_code == 200
+    after = client.get("/api/v1/uploads", headers=headers)
+    assert after.json()["data"] == []


### PR DESCRIPTION
## Summary
- track uploaded files in a new `uploads` table
- validate file size and type on upload
- return presigned download links
- list and delete uploads via new endpoints
- secure MinIO operations and update tests
- document new routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886345b5c408327b012b05b4102a86c