### PR TITLE
Conversation export and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,11 +106,13 @@ limited. The `/auth/logout` endpoint now invalidates the provided token and
 | PATCH | `/api/v1/conversations/{conversation_id}` | Update conversation |
 | DELETE | `/api/v1/conversations/{conversation_id}` | Delete conversation |
 | DELETE | `/api/v1/conversations` | Bulk delete conversations |
+| GET | `/api/v1/conversations/export` | Export conversation summaries |
 | GET | `/api/v1/conversations/{conversation_id}/messages` | List messages in conversation |
 | POST | `/api/v1/conversations/{conversation_id}/messages` | Create message in conversation |
 | GET | `/api/v1/messages/{message_id}` | Get message |
 | PATCH | `/api/v1/messages/{message_id}` | Update message |
 | DELETE | `/api/v1/messages/{message_id}` | Delete message |
+| GET | `/api/v1/messages/search` | Search messages |
 | POST | `/api/v1/uploads` | Upload file |
 | GET | `/api/v1/uploads` | List user uploads |
 | DELETE | `/api/v1/uploads/{upload_id}` | Delete uploaded file |

--- a/app/repositories/conversation.py
+++ b/app/repositories/conversation.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from uuid import UUID
 from sqlalchemy.orm import Session
 from app.models.conversation import Conversation
+from app.repositories.message import count_messages
 
 
 def create_conversation(db: Session, user_id: UUID, title: Optional[str] = None) -> Conversation:
@@ -49,3 +50,18 @@ def bulk_delete(db: Session, user_id: UUID, ids: List[UUID]) -> int:
     count = q.delete(synchronize_session=False)
     db.commit()
     return count
+
+
+def export_summaries(db: Session, user_id: UUID) -> List[dict]:
+    """Return conversation summaries with message counts."""
+    convos = list_conversations(db, user_id)
+    summaries = []
+    for conv in convos:
+        summaries.append(
+            {
+                "conversation_id": conv.conversation_id,
+                "title": conv.title,
+                "message_count": count_messages(db, conv.conversation_id),
+            }
+        )
+    return summaries

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,6 +1,11 @@
 from .chat import ChatRequest, ChatResponse
 from .user import UserCreate, UserRead, UserUpdate
-from .conversation import ConversationCreate, ConversationRead, ConversationUpdate
+from .conversation import (
+    ConversationCreate,
+    ConversationRead,
+    ConversationUpdate,
+    ConversationSummary,
+)
 from .message import MessageCreate, MessageRead, MessageUpdate
 from .usage import UsageRead
 from .upload import UploadRead
@@ -25,6 +30,7 @@ __all__ = [
     "ConversationCreate",
     "ConversationRead",
     "ConversationUpdate",
+    "ConversationSummary",
     "MessageCreate",
     "MessageRead",
     "MessageUpdate",

--- a/app/schemas/conversation.py
+++ b/app/schemas/conversation.py
@@ -20,3 +20,11 @@ class ConversationRead(ConversationBase):
     updated_at: Optional[datetime] = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ConversationSummary(BaseModel):
+    conversation_id: UUID
+    title: Optional[str] = None
+    message_count: int
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- add API endpoint to export conversation summaries
- enable message search with /messages/search
- trigger LLM for `ai` or `tool` messages
- support message export and search in repository layer
- document new routes
- test plan limit edges and new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863883ce74832786fad41597faf4f4