### PR TITLE
Add user restore endpoint and docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The aim of the project is to stay lightweight and easy to extend.
 ## Running with Docker Compose
 
 The project includes a `docker-compose.yml` that starts the API together with
-Redis, MinIO, Qdrant and Postgres. Build the stack once and start it with:
+Redis, MinIO and Postgres. Build the stack once and start it with:
 
 ```bash
 docker compose up --build
@@ -35,6 +35,9 @@ dependencies.
 
 Copy `.env.example` to `.env` and fill in the values. To enable the chat
 endpoint you must provide a valid `OPENAI_API_KEY`.
+
+The upload routes store files in a MinIO bucket configured via the `MINIO_*`
+environment variables.
 
 ### Database migrations
 
@@ -124,6 +127,7 @@ limited. The `/auth/logout` endpoint now invalidates the provided token and
 | GET | `/api/v1/admin/users/{user_id}/usage` | Admin view user's usage |
 | POST | `/api/v1/admin/users/{user_id}/suspend` | Suspend user |
 | POST | `/api/v1/admin/users/{user_id}/reinstate` | Reinstate user |
+| POST | `/api/v1/admin/users/{user_id}/restore` | Restore deleted user |
 | POST | `/api/v1/moderation/stage-in` | Stage incoming message |
 | POST | `/api/v1/moderation/stage-out` | Stage outgoing message |
 | GET | `/api/v1/moderation` | List staged messages |
@@ -151,7 +155,7 @@ require a valid JWT `Authorization` header. The authenticated user must have
 
 - Replace in-memory rate limiting with Redis for horizontal scaling
 - Add background job queue for long running tasks
-- Implement OAuth providers for enterprise authentication
+- Implement OAuth/OIDC providers for enterprise authentication (see `docs/OAUTH_OIDC.md`)
 - Provide OpenAPI schemas for client code generation
 - Integrate payment processing in `charge_plan` to bill upgrades
 

--- a/app/api/v1/endpoints/admin.py
+++ b/app/api/v1/endpoints/admin.py
@@ -133,3 +133,18 @@ def admin_reinstate_user(user_id: UUID, db: Session = Depends(get_db)) -> UserRe
     reinstated = user_repo.reinstate_user(db, user)
     logger.info("Admin reinstated user %s", user_id)
     return success(UserRead.model_validate(reinstated)).dict()
+
+
+@router.post(
+    "/users/{user_id}/restore",
+    response_model=StandardResponse,
+    summary="Restore user",
+)
+def admin_restore_user(user_id: UUID, db: Session = Depends(get_db)) -> UserRead:
+    """Restore a soft-deleted user."""
+    user = user_repo.get_user_include_deleted(db, user_id)
+    if not user or user.deleted_at is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    restored = user_repo.restore_user(db, user)
+    logger.info("Admin restored user %s", user_id)
+    return success(UserRead.model_validate(restored)).dict()

--- a/app/repositories/user.py
+++ b/app/repositories/user.py
@@ -28,6 +28,11 @@ def get_user(db: Session, user_id: UUID) -> Optional[User]:
     )
 
 
+def get_user_include_deleted(db: Session, user_id: UUID) -> Optional[User]:
+    """Return a user regardless of deletion state."""
+    return db.query(User).filter(User.user_id == user_id).first()
+
+
 def get_user_by_email(db: Session, email: str) -> Optional[User]:
     """Retrieve a user by email."""
     return (
@@ -75,6 +80,15 @@ def suspend_user(db: Session, user: User) -> User:
 def reinstate_user(db: Session, user: User) -> User:
     """Reinstate a suspended user."""
     user.is_suspended = False
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def restore_user(db: Session, user: User) -> User:
+    """Restore a soft-deleted user."""
+    user.is_active = True
+    user.deleted_at = None
     db.commit()
     db.refresh(user)
     return user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - postgres
       - redis
       - minio
-      - qdrant
   postgres:
     image: postgres:15
     restart: always
@@ -38,8 +37,3 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
-  qdrant:
-    image: qdrant/qdrant:latest
-    restart: always
-    ports:
-      - "6333:6333"

--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -98,15 +98,29 @@ The current service exposes a minimal set of endpoints:
 | GET    | `/api/v1/conversations/{conversation_id}` | Get conversation |
 | PATCH  | `/api/v1/conversations/{conversation_id}` | Update conversation |
 | DELETE | `/api/v1/conversations/{conversation_id}` | Delete conversation |
+| DELETE | `/api/v1/conversations` | Bulk delete conversations |
+| GET    | `/api/v1/conversations/export` | Export conversation summaries |
 | GET    | `/api/v1/conversations/{conversation_id}/messages` | List messages in conversation |
 | POST   | `/api/v1/conversations/{conversation_id}/messages` | Create message in conversation |
 | GET    | `/api/v1/messages/{message_id}` | Get message |
 | PATCH  | `/api/v1/messages/{message_id}` | Update message |
 | DELETE | `/api/v1/messages/{message_id}` | Delete message |
+| GET    | `/api/v1/messages/search` | Search messages |
+| POST   | `/api/v1/uploads` | Upload file |
+| GET    | `/api/v1/uploads` | List user uploads |
+| DELETE | `/api/v1/uploads/{upload_id}` | Delete uploaded file |
 | GET    | `/api/v1/admin/users` | Admin list users |
 | POST   | `/api/v1/admin/users` | Admin create user |
 | PATCH  | `/api/v1/admin/users/{user_id}` | Admin update user |
 | DELETE | `/api/v1/admin/users/{user_id}` | Admin delete user |
+| GET    | `/api/v1/admin/users/{user_id}/conversations` | Admin view user's conversations |
+| GET    | `/api/v1/admin/users/{user_id}/usage` | Admin view user's usage |
+| POST   | `/api/v1/admin/users/{user_id}/suspend` | Suspend user |
+| POST   | `/api/v1/admin/users/{user_id}/reinstate` | Reinstate user |
+| POST   | `/api/v1/admin/users/{user_id}/restore` | Restore deleted user |
+| POST   | `/api/v1/moderation/stage-in` | Stage incoming message |
+| POST   | `/api/v1/moderation/stage-out` | Stage outgoing message |
+| GET    | `/api/v1/moderation` | List staged messages |
 
 ### User actions
 

--- a/docs/OAUTH_OIDC.md
+++ b/docs/OAUTH_OIDC.md
@@ -1,0 +1,12 @@
+# OAuth and OIDC Support (Planned)
+
+Flynkle currently uses a simple username/password login with JWTs. The project aims to support OAuth and OpenID Connect providers such as Google or Azure AD in the future. This document will outline the approach once implementation begins.
+
+Expected steps:
+
+1. Add an OAuth library (e.g. `Authlib`) and configure providers.
+2. Allow users to link external accounts during signup.
+3. Issue the same JWT tokens after a successful OAuth/OIDC login.
+4. Update tests and documentation.
+
+This is a placeholder until the feature is implemented.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ fastapi
 uvicorn
 redis
 minio
-qdrant-client
 SQLAlchemy
 psycopg2-binary
 alembic


### PR DESCRIPTION
## Summary
- allow admins to restore soft-deleted users
- document OAuth/OIDC plans
- note MinIO configuration and remove unused Qdrant
- refresh endpoint tables

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68863d4433d48327b5acff8e86d3fe6f